### PR TITLE
fix: zero initialize memory alloacted through malloc in bounded_malloc

### DIFF
--- a/seahorn/lib/proof_allocators.c
+++ b/seahorn/lib/proof_allocators.c
@@ -91,7 +91,14 @@ void *bounded_calloc(size_t num, size_t size) {
 
 void *bounded_malloc(size_t size) {
     assume(size <= MEM_BLOCK);
-    return malloc(MEM_BLOCK);
+    void *ptr =  malloc(MEM_BLOCK);
+    // zero-initialize the array since if caller
+    // assumes immediately after calling bounded_malloc
+    // it will be a read before write causing the
+    // compiler to treat it as undef behaviour
+    // thereby removing the read.
+    memset(ptr, 0, size);
+    return ptr;
 }
 
 /************************************************************************************************************/


### PR DESCRIPTION
This will remove dependence on caller to do the correct thing after allocating i.e. writing to memory