### PR TITLE
fix: aws_array_eq_c_str harness

### DIFF
--- a/seahorn/include/utils.h
+++ b/seahorn/include/utils.h
@@ -121,7 +121,10 @@ uint64_t uninterpreted_hasher(const void *a);
  */
 bool uninterpreted_predicate_fn(uint8_t value);
 
-unsigned sea_strlen(const char *str);
+size_t sea_strlen(const char *str, size_t max);
+
+// len is populated by this function
+const char *ensure_c_str_is_nd_allocated(size_t max_size, size_t* len);
 
 const char *ensure_c_str_is_allocated(size_t max_size);
 

--- a/seahorn/jobs/array_eq_c_str/aws_array_eq_c_str_harness.c
+++ b/seahorn/jobs/array_eq_c_str/aws_array_eq_c_str_harness.c
@@ -11,16 +11,15 @@ int main() {
     /* assumptions */
     size_t array_len = nd_size_t();
     assume(array_len <= MAX_BUFFER_SIZE);
+    // TODO: Can malloc fail?
     void *array = bounded_malloc(MAX_BUFFER_SIZE);
-    const char *c_str = nd_bool() ? NULL : ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
-
+    size_t str_len = 0;
+    const char *c_str = ensure_c_str_is_nd_allocated(MAX_BUFFER_SIZE, &str_len);
     /* save current state of the parameters */
     struct store_byte_from_buffer old_byte_from_array;
     save_byte_from_array((uint8_t *)array, array_len, &old_byte_from_array);
-    size_t str_len = (c_str) ? sea_strlen(c_str) : 0;
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
-
     /* pre-conditions */
     assume(array || (array_len == 0));
     assume(c_str);

--- a/seahorn/lib/proof_allocators.c
+++ b/seahorn/lib/proof_allocators.c
@@ -14,7 +14,7 @@
 int8_t *g_ptr0 = NULL;
 size_t g_ptr0_size;
 
-extern void memset_nd(void *ptr);
+extern void memset_nd(void *ptr, size_t size);
 
 void *realloc( void *ptr, size_t new_size ) {
     if (ptr) {
@@ -99,7 +99,7 @@ void *bounded_malloc(size_t size) {
     // it will be a read before write causing the
     // compiler to treat it as undef behaviour
     // thereby removing the read.
-    memset_nd(ptr);
+    memset_nd(ptr, size);
     return ptr;
 }
 

--- a/seahorn/lib/utils.c
+++ b/seahorn/lib/utils.c
@@ -107,10 +107,28 @@ void assert_byte_cursor_equivalence(
     }
 }
 
-unsigned sea_strlen(const char *str) {
-    unsigned i=0;
-    for (unsigned i=0; str[i] != '\0' && i < MAX_BUFFER_SIZE-1; ++i);
+size_t sea_strlen(const char *str, size_t max) {
+    size_t i;
+    i = nd_size_t();
+    assume(i <= max && max <= MAX_BUFFER_SIZE);
+    assume(str[i] == '\0');
+    // The following assumption cannot be expressed
+    // assume(forall j :: j < i ==> str[j] != '\0');
+    // therefore, we say the following:
+    size_t j = 0;
+    for (j = 0; j < MAX_BUFFER_SIZE; j++) {
+        if (j < i) { 
+            assume(str[j] != '\0'); 
+        }
+    }
     return i;
+}
+
+const char *ensure_c_str_is_nd_allocated(size_t max_size, size_t *len) {
+    // use bounded_nd_malloc to ensure that string is initialized
+    const char *str = bounded_malloc(MAX_BUFFER_SIZE);
+    *len = sea_strlen(str, max_size);
+    return str;
 }
 
 const char *ensure_c_str_is_allocated(size_t max_size) {

--- a/verify-c-common.sh
+++ b/verify-c-common.sh
@@ -8,7 +8,7 @@ shift
 SEA_DIR=${1}
 shift
 
-${SEA_DIR}/sea fpf --sea-dsa=cs+t  -m32 -O0  --inline  --horn-bmc-engine=mono --horn-bmc --horn-bv2=true \
+${SEA_DIR}/sea fpf --sea-dsa=cs+t  -O3  --inline  --horn-bmc-engine=mono --horn-bmc --horn-bv2=true \
                    --log=opsem  --sea-opsem-allocator=normal  --keep-shadows=true --horn-bv2-simplify=true \
                    --horn-bv2-lambdas --horn-gsa --horn-vcgen-use-ite --horn-bv2-ptr-size=8 --horn-bv2-word-size=8 \
                    --horn-bv2-extra-widemem --keep-temps --temp-dir=/tmp/verify-c-common \


### PR DESCRIPTION
1. verified that all harness branches are being taken by adding sassert(0)
2. changed harness to disallow null c_str  creation
3. changed malloc to use memset_nd() (earlier memset0 was used)
4. changed sea_strlen to assume that the first 0 is at end of string (none before)
5. changed verify_c_common.sh script to use -O3. This enables automatic unrolling of forall() for loop in sea_strlen
6. added c_str_is_nd_allocated() fn to allocate str and return length