### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        verify_flag: ["", "--vac", "--vac --horn-bmc-solver=smt-y2", "--cex", "--cex --horn-bmc-solver=smt-y2"]
+
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@master
+     
+      - name: Docker 
+        run: docker build -t verify-c-common . --file docker/verify-c-common.Dockerfile
+        
+      - name: Get number of Cores
+        id: cores
+        run: echo "::set-output name=num_cores::$(nproc --all)"
+        
+      - name: Run Tests 
+        run: docker run -t verify-c-common /bin/bash -c "cd build && env VERIFY_FLAGS=${{ matrix.verify_flag }} ctest -j ${{steps.cores.outputs.num_cores}} --timeout 2000"
+        if: matrix.verify_flag == ''
+        
+      - name: Run vac Tests 
+        run: docker run -t verify-c-common /bin/bash -c "cd build && env VERIFY_FLAGS=${{ matrix.verify_flag }} ctest -j ${{steps.cores.outputs.num_cores}} --timeout 2000 -E \"(ring_buffer_clean_up_unsat_test)\""
+        if: matrix.verify_flag == '--vac' || matrix.verify_flag == '--vac --horn-bmc-solver=smt-y2'
+        
+      - name: Run cex Tests 
+        run: docker run -t verify-c-common /bin/bash -c "cd build && env VERIFY_FLAGS=${{ matrix.verify_flag }} ctest -j ${{steps.cores.outputs.num_cores}} --timeout 2000 -E \"(byte_buf_write_from_whole_string_unsat_test|linked_list_pop_back_unsat_test|linked_list_swap_contents_unsat_test|string_eq_unsat_test|ring_buffer_clean_up_unsat_test|string_compare_unsat_test)\""
+        if: matrix.verify_flag == '--cex' || matrix.verify_flag == '--cex --horn-bmc-solver=smt-y2'
+        


### PR DESCRIPTION
The timeout is set to 2000s currently. 
For --vac, ring_buffer_clean_up_unsat_test takes too long so was excluded. 
For --cex, 
- byte_buf_write_from_whole_string_unsat_test
- linked_list_pop_back_unsat_test
- linked_list_swap_contents_unsat_test
- string_eq_unsat_test
- ring_buffer_clean_up_unsat_test
- string_compare_unsat_test
were taking too long and were commented out. 

These two test are failing for --cex (not timeout issue)
30 - array_list_set_at_unsat_test (Failed)
76 - byte_cursor_from_string_unsat_test (Failed)