### PR TITLE
fix(jobs): remove smtfd tactics from jobs that are failing falsely

### DIFF
--- a/seahorn/jobs/array_list_set_at/sea.yaml
+++ b/seahorn/jobs/array_list_set_at/sea.yaml
@@ -1,2 +1,2 @@
 verify_options:
-  horn-bmc-tactic: smtfd
+  horn-bv2-word-size: 1

--- a/seahorn/jobs/byte_cursor_from_string/sea.yaml
+++ b/seahorn/jobs/byte_cursor_from_string/sea.yaml
@@ -1,3 +1,2 @@
 verify_options:
   horn-bv2-word-size: 1
-  horn-bmc-tactic: smtfd


### PR DESCRIPTION
`array_list_set_at` and `byte_cursor_from_string` are failing in cex with solver tactic set to `smtfd` https://github.com/seahorn/verify-c-common/runs/1532417861?check_suite_focus=true
use default tactic instead