### PR TITLE
Benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ enable_testing()
 
 option(SEA_ENABLE_FUZZ "Enable fuzzing" OFF)
 option(SEA_WITH_BLEEDING_EDGE "Enable bleeding edge proofs" OFF)
-
+option(SEA_ENABLE_BENCHMARK "Enable benchmarking jobs" OFF)
 option(SEA_ENABLE_KLEE "Enable klee" OFF)
 
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR )

--- a/seahorn/CMakeLists.txt
+++ b/seahorn/CMakeLists.txt
@@ -469,5 +469,6 @@ endif()
 
 if(${SEA_ENABLE_BENCHMARK})
   add_subdirectory(benchmark_jobs/linked_list_pop_back_benchmark)
+  add_subdirectory(benchmark_jobs/linked_list_swap_contents_benchmark)
 endif()
 

--- a/seahorn/CMakeLists.txt
+++ b/seahorn/CMakeLists.txt
@@ -466,3 +466,8 @@ if(${SEA_WITH_BLEEDING_EDGE})
   add_subdirectory(jobs/ring_buffer_buf_belongs_to_pool)
   add_subdirectory(jobs/ring_buffer_acquire_up_to)
 endif()
+
+if(${SEA_ENABLE_BENCHMARK})
+  add_subdirectory(benchmark_jobs/linked_list_pop_back_benchmark)
+endif()
+

--- a/seahorn/benchmark_jobs/linked_list_pop_back_benchmark/CMakeLists.txt
+++ b/seahorn/benchmark_jobs/linked_list_pop_back_benchmark/CMakeLists.txt
@@ -1,0 +1,9 @@
+# add head and tail to list size.
+MATH(EXPR UNROLL_BOUND "${MAX_LINKED_LIST_ITEM_ALLOCATION_SIZE} + 2")
+add_executable(linked_list_pop_back_benchmark
+  aws_linked_list_pop_back_harness.c)
+target_compile_definitions(linked_list_pop_back_benchmark
+  # We will use our own function for is_valid check hence AWS_DEEP_CHECK is off
+  PUBLIC AWS_DEEP_CHECKS=0)
+sea_attach_bc_link(linked_list_pop_back_benchmark)
+sea_add_unsat_test(linked_list_pop_back_benchmark)

--- a/seahorn/benchmark_jobs/linked_list_pop_back_benchmark/aws_linked_list_pop_back_harness.c
+++ b/seahorn/benchmark_jobs/linked_list_pop_back_benchmark/aws_linked_list_pop_back_harness.c
@@ -1,0 +1,86 @@
+#include "nondet.h"
+#include <aws/common/linked_list.h>
+
+#include <seahorn/seahorn.h>
+
+extern NONDET_FN_ATTR struct aws_linked_list_node *nd_linked_list_node(void);
+
+int main(void) {
+  // -- handles the case of list of size > 1
+  // -- list of size 1 must be handled differently
+
+  /* data structure */
+  struct aws_linked_list list;
+
+  // -- partially initialize the list so that only the last element is
+  // -- accessible and can be properly removed
+
+  // -- element to be removed
+  struct aws_linked_list_node node1;
+
+  // -- tail
+  list.tail.prev = &node1;
+  list.tail.next = NULL;
+
+  // -- head
+  struct aws_linked_list_node *list_head_next_old = nd_linked_list_node();
+  list.head.prev = NULL;
+  // -- pointer that cannot be derefed
+  list.head.next = list_head_next_old;
+
+  // -- potential predecessor of node1
+  struct aws_linked_list_node node2;
+  struct aws_linked_list_node *node2_prev_old = nd_linked_list_node();
+  // -- pointer that cannot be derefed
+  node2.prev = node2_prev_old;
+
+  // -- special case of a linked list of size 1
+  bool len_one = nd_bool();
+
+  // -- points to predecessor of node to be removed
+  struct aws_linked_list_node *pnode;
+
+  // -- if len is 1, predecessor is head, ow it is node2
+  if (len_one) {
+    pnode = &list.head;
+  } else {
+    pnode = &node2;
+  }
+
+  // -- setup predecessor to come before node1
+  struct aws_linked_list_node *pnode_prev_old;
+  pnode->next = &node1;
+  pnode_prev_old = pnode->prev;
+
+  node1.prev = pnode;
+  node1.next = &list.tail;
+
+  /* Assume the preconditions. The function requires that list != NULL */
+  assume(!aws_linked_list_empty(&list));
+
+  /* Keep the old last node of the linked list */
+  struct aws_linked_list_node *old_prev_last = (list.tail.prev)->prev;
+
+  /* perform operation under verification */
+  struct aws_linked_list_node *ret = aws_linked_list_pop_back(&list);
+
+  // -- removed node is detached
+  sassert(ret->next == NULL);
+  sassert(ret->prev == NULL);
+
+  // -- tail of list is properly updated
+  sassert(list.tail.prev == old_prev_last);
+
+  // -- list is ok
+  sassert(list.head.prev == NULL);
+  sassert(list.tail.next == NULL);
+
+  // -- accessible memory is not modified
+  if (!len_one)
+    sassert(list.head.next == list_head_next_old);
+  else
+    sassert(aws_linked_list_empty(&list));
+  sassert(node2.prev == node2_prev_old);
+
+  return 0;
+}

--- a/seahorn/benchmark_jobs/linked_list_swap_contents_benchmark/CMakeLists.txt
+++ b/seahorn/benchmark_jobs/linked_list_swap_contents_benchmark/CMakeLists.txt
@@ -1,0 +1,6 @@
+# add head and tail to list size.
+add_executable(linked_list_swap_contents_benchmark
+  aws_linked_list_swap_contents_harness.c)
+sea_attach_bc_link(linked_list_swap_contents_benchmark)
+sea_add_unsat_test(linked_list_swap_contents_benchmark)
+

--- a/seahorn/benchmark_jobs/linked_list_swap_contents_benchmark/aws_linked_list_swap_contents_harness.c
+++ b/seahorn/benchmark_jobs/linked_list_swap_contents_benchmark/aws_linked_list_swap_contents_harness.c
@@ -1,0 +1,119 @@
+#include "nondet.h"
+#include <aws/common/linked_list.h>
+#include <seahorn/seahorn.h>
+
+extern NONDET_FN_ATTR struct aws_linked_list_node *nd_linked_list_node(void);
+
+void sea_nd_init_linked_list(struct aws_linked_list *list, size_t *len) {
+  aws_linked_list_init(list);
+
+  if (nd_bool()) {
+    *len = 0;
+    return;
+  }
+
+  if (nd_bool()) {
+    *len = 1;
+    struct aws_linked_list_node *node;
+    node = malloc(sizeof(struct aws_linked_list_node));
+    assume(node);
+    aws_linked_list_push_front(list, node);
+    return;
+  }
+
+  // -- list of size >1
+  size_t nd_len = nd_size_t();
+  assume(nd_len > 1);
+  *len = nd_len;
+
+  struct aws_linked_list_node *node1;
+  struct aws_linked_list_node *node2;
+
+  node1 = malloc(sizeof(struct aws_linked_list_node));
+  node2 = malloc(sizeof(struct aws_linked_list_node));
+
+  // -- nd_linked_list() cannot be derefed, so the list is not accessible
+  // -- except for the first and last elements. This also ensures that
+  // -- inaccessible elements are not touched by any function that manpulates
+  // -- the linst.
+  list->head.next = node1;
+  node1->prev = &list->head;
+  node1->next = nd_linked_list_node();
+
+  node2->prev = nd_linked_list_node();
+  node2->next = &list->tail;
+  list->tail.prev = nd_linked_list_node();
+}
+
+int main(void) {
+  /* data structure */
+  struct aws_linked_list a, b;
+  size_t a_len, b_len;
+
+  sea_nd_init_linked_list(&a, &a_len);
+  sea_nd_init_linked_list(&b, &b_len);
+
+  struct aws_linked_list a_old, b_old;
+  a_old = a;
+  b_old = b;
+
+  void *a_head_next_next_old;
+  void *b_head_next_next_old;
+  void *a_tail_prev_prev_old;
+  void *b_tail_prev_prev_old;
+
+  // -- the first and the last elements of the list are accessible
+  // -- store values that should not be cahnged to compare with later
+  if (a_len > 0) {
+    a_head_next_next_old = a.head.next->next;
+    a_tail_prev_prev_old = a.tail.prev->prev;
+  }
+
+  if (b_len > 0) {
+    b_head_next_next_old = b.head.next->next;
+    b_tail_prev_prev_old = b.tail.prev->prev;
+  }
+
+  /* perform operation under verification */
+  aws_linked_list_swap_contents(&a, &b);
+
+  // -- basic properties of head and tail
+  sassert(a.head.prev == NULL);
+  sassert(a.tail.next == NULL);
+  sassert(b.head.prev == NULL);
+  sassert(b.tail.next == NULL);
+
+  sassert(aws_linked_list_node_next_is_valid(&a.head));
+  sassert(aws_linked_list_node_prev_is_valid(&a.tail));
+
+  sassert(aws_linked_list_node_next_is_valid(&b.head));
+  sassert(aws_linked_list_node_prev_is_valid(&b.tail));
+
+  if (a_len == 0) {
+    // if a was empty, then b is empty after swap
+    sassert(aws_linked_list_empty(&b));
+  } else {
+    // if a was not empty, b points to the list of a
+    sassert(b.head.next == a_old.head.next);
+    sassert(b.tail.prev == a_old.tail.prev);
+    if (a_len > 1) {
+      // if a had >1 elements, check pointers of first and last element
+      sassert(b.head.next->next == a_head_next_next_old);
+      sassert(b.tail.prev->prev == a_tail_prev_prev_old);
+    }
+  }
+
+  // -- same check as above but for b
+  if (b_len == 0) {
+    sassert(aws_linked_list_empty(&a));
+  } else {
+    sassert(a.head.next == b_old.head.next);
+    sassert(a.tail.prev == b_old.tail.prev);
+    if (b_len > 1) {
+      sassert(a.head.next->next == b_head_next_next_old);
+      sassert(a.tail.prev->prev == b_tail_prev_prev_old);
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
pop_back benchmark jobs runs in same amount of time.
swap_contents job runs much faster


To help debug: https://github.com/seahorn/verify-c-common/issues/24