### PR TITLE
Klee covers more harnesses

### DIFF
--- a/seahorn/jobs/byte_cursor_left_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_left_trim_pred/CMakeLists.txt
@@ -5,3 +5,7 @@ sea_attach_bc_link(byte_cursor_left_trim_pred)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_left_trim_pred)
 
+# klee
+sea_add_klee(byte_cursor_left_trim_pred
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_byte_cursor_left_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
@@ -6,6 +6,12 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
+#ifdef __KLEE__
+bool uninterpreted_predicate_fn(uint8_t value) {
+    return nd_bool();
+}
+#endif
+
 int main() {
     /* parameters */
     struct aws_byte_cursor cur;

--- a/seahorn/jobs/byte_cursor_right_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_right_trim_pred/CMakeLists.txt
@@ -4,3 +4,8 @@ add_executable(byte_cursor_right_trim_pred
 sea_attach_bc_link(byte_cursor_right_trim_pred)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_right_trim_pred)
+
+# klee
+sea_add_klee(byte_cursor_right_trim_pred
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_byte_cursor_right_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
@@ -8,6 +8,12 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
+#ifdef __KLEE__
+bool uninterpreted_predicate_fn(uint8_t value) {
+    return nd_bool();
+}
+#endif
+
 int main() {
     /* parameters */
     struct aws_byte_cursor cur;

--- a/seahorn/jobs/byte_cursor_satisfies_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_satisfies_pred/CMakeLists.txt
@@ -4,3 +4,8 @@ add_executable(byte_cursor_satisfies_pred
 sea_attach_bc_link(byte_cursor_satisfies_pred)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_satisfies_pred)
+
+# klee
+sea_add_klee(byte_cursor_satisfies_pred
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_byte_cursor_satisfies_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
@@ -8,6 +8,12 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
+#ifdef __KLEE__
+bool uninterpreted_predicate_fn(uint8_t value) {
+    return nd_bool();
+}
+#endif
+
 int main() {
     /* parameters */
     struct aws_byte_cursor cur;

--- a/seahorn/jobs/byte_cursor_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_trim_pred/CMakeLists.txt
@@ -4,3 +4,8 @@ add_executable(byte_cursor_trim_pred
 sea_attach_bc_link(byte_cursor_trim_pred)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_trim_pred)
+
+# klee
+sea_add_klee(byte_cursor_trim_pred
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_byte_cursor_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -8,6 +8,12 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
+#ifdef __KLEE__
+bool uninterpreted_predicate_fn(uint8_t value) {
+    return nd_bool();
+}
+#endif
+
 int main() {
     /* parameters */
     struct aws_byte_cursor cur;

--- a/seahorn/jobs/linked_list_pop_back/aws_linked_list_pop_back_harness.c
+++ b/seahorn/jobs/linked_list_pop_back/aws_linked_list_pop_back_harness.c
@@ -11,6 +11,8 @@ int main(void) {
   struct saved_aws_linked_list to_save = {.saved_size = 0};
   #ifdef __KLEE__
     if (size == 0) return 0;
+  #else
+    assume(size > 0);
   #endif
 
   /* Keep the old last node of the linked list */

--- a/seahorn/jobs/priority_queue_s_sift_either/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_sift_either/CMakeLists.txt
@@ -3,11 +3,6 @@ add_executable(
   ${AWS_C_COMMON_ROOT}/source/array_list.c
   aws_priority_queue_s_sift_either_harness.c
 )
-target_compile_definitions(
-  priority_queue_s_sift_either
-  PUBLIC MAX_PRIORITY_QUEUE_ITEMS=5
-  MAX_HEAP_HEIGHT=3
-)
 sea_link_libraries(priority_queue_s_sift_either priority_queue.opt.ir)
 sea_attach_bc_link(priority_queue_s_sift_either)
 configure_file(sea.yaml sea.yaml @ONLY)

--- a/seahorn/jobs/priority_queue_s_sift_up/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_sift_up/CMakeLists.txt
@@ -3,11 +3,6 @@ add_executable(
   ${AWS_C_COMMON_ROOT}/source/array_list.c
   aws_priority_queue_s_sift_up_harness.c
 )
-target_compile_definitions(
-  priority_queue_s_sift_up
-  PUBLIC MAX_PRIORITY_QUEUE_ITEMS=5
-  MAX_HEAP_HEIGHT=3
-)
 sea_link_libraries(priority_queue_s_sift_up priority_queue.opt.ir)
 sea_attach_bc_link(priority_queue_s_sift_up)
 configure_file(sea.yaml sea.yaml @ONLY)

--- a/seahorn/jobs/ptr_eq/CMakeLists.txt
+++ b/seahorn/jobs/ptr_eq/CMakeLists.txt
@@ -3,3 +3,8 @@ add_executable(ptr_eq
   aws_ptr_eq_harness.c)
 sea_attach_bc_link(ptr_eq)
 sea_add_unsat_test(ptr_eq)
+
+# klee
+sea_add_klee(ptr_eq
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_ptr_eq_harness.c)

--- a/seahorn/jobs/ring_buffer_acquire/CMakeLists.txt
+++ b/seahorn/jobs/ring_buffer_acquire/CMakeLists.txt
@@ -4,3 +4,9 @@ add_executable(ring_buffer_acquire
   aws_ring_buffer_acquire_harness.c)
 sea_attach_bc_link(ring_buffer_acquire)
 sea_add_unsat_test(ring_buffer_acquire)
+
+# klee
+sea_add_klee(ring_buffer_acquire
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/ring_buffer.c
+  aws_ring_buffer_acquire_harness.c)

--- a/seahorn/jobs/ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/seahorn/jobs/ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -12,6 +12,7 @@
 #include <proof_allocators.h>
 #include <ring_buffer_helper.h>
 #include <seahorn/seahorn.h>
+#include <utils.h>
 
 int main(void) {
   /* parameters */
@@ -24,6 +25,7 @@ int main(void) {
   initialize_ring_buffer(&ring_buf, ring_buf_size);
 
   size_t requested_size = nd_size_t();
+  KLEE_ASSUME(requested_size <= KLEE_MAX_SIZE);
 
   /* assumptions */
   assume(aws_ring_buffer_is_valid(&ring_buf));

--- a/seahorn/jobs/ring_buffer_acquire_up_to/CMakeLists.txt
+++ b/seahorn/jobs/ring_buffer_acquire_up_to/CMakeLists.txt
@@ -5,3 +5,9 @@ add_executable(ring_buffer_acquire_up_to
 sea_attach_bc_link(ring_buffer_acquire_up_to)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(ring_buffer_acquire_up_to)
+
+# klee
+sea_add_klee(ring_buffer_acquire_up_to
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/ring_buffer.c
+  aws_ring_buffer_acquire_up_to_harness.c)

--- a/seahorn/jobs/ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/seahorn/jobs/ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -12,6 +12,7 @@
 #include <proof_allocators.h>
 #include <ring_buffer_helper.h>
 #include <seahorn/seahorn.h>
+#include <utils.h>
 
 int main(void) {
   /* parameters */
@@ -25,6 +26,7 @@ int main(void) {
 
   size_t minimum_size = nd_size_t();
   size_t requested_size = nd_size_t();
+  KLEE_ASSUME(requested_size <= KLEE_MAX_SIZE);
 
   /* assumptions */
   assume(requested_size >= minimum_size);

--- a/seahorn/jobs/ring_buffer_clean_up/CMakeLists.txt
+++ b/seahorn/jobs/ring_buffer_clean_up/CMakeLists.txt
@@ -4,3 +4,9 @@ add_executable(ring_buffer_clean_up
   aws_ring_buffer_clean_up_harness.c)
 sea_attach_bc_link(ring_buffer_clean_up)
 sea_add_unsat_test(ring_buffer_clean_up)
+
+# klee
+sea_add_klee(ring_buffer_clean_up
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/ring_buffer.c
+  aws_ring_buffer_clean_up_harness.c)

--- a/seahorn/jobs/ring_buffer_init/CMakeLists.txt
+++ b/seahorn/jobs/ring_buffer_init/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable(ring_buffer_init
   aws_ring_buffer_init_harness.c)
 sea_attach_bc_link(ring_buffer_init)
 sea_add_unsat_test(ring_buffer_init)
+
+# klee
+sea_add_klee(ring_buffer_init
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/ring_buffer.c
+  aws_ring_buffer_init_harness.c)

--- a/seahorn/jobs/ring_buffer_init/aws_ring_buffer_init_harness.c
+++ b/seahorn/jobs/ring_buffer_init/aws_ring_buffer_init_harness.c
@@ -5,6 +5,7 @@
 #include <nondet.h>
 #include <seahorn/seahorn.h>
 #include <proof_allocators.h>
+#include <utils.h>
 
 int main(void) {
   /* parameters */
@@ -13,6 +14,7 @@ int main(void) {
   size_t size;
   size = nd_size_t();
   assume(size > 0); /* Precondition */
+  KLEE_ASSUME(size <= KLEE_MAX_SIZE);
 
   if (aws_ring_buffer_init(&ring_buf, allocator, size) == AWS_OP_SUCCESS) {
     /* assertions */

--- a/seahorn/jobs/round_up_to_power_of_two/CMakeLists.txt
+++ b/seahorn/jobs/round_up_to_power_of_two/CMakeLists.txt
@@ -2,3 +2,7 @@ add_executable(round_up_to_power_of_two
   aws_round_up_to_power_of_two_harness.c)
 sea_attach_bc_link(round_up_to_power_of_two)
 sea_add_unsat_test(round_up_to_power_of_two)
+
+# klee
+sea_add_klee(round_up_to_power_of_two
+  aws_round_up_to_power_of_two_harness.c)

--- a/seahorn/lib/CMakeLists.txt
+++ b/seahorn/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(
   klee_string_helper.c
   klee_priority_queue_helper.c
   utils.c
+  klee_ring_buffer_helper.c
   klee_allocators.c
   sea_allocators.c
   allocator_override.c

--- a/seahorn/lib/klee_byte_buf_helper.c
+++ b/seahorn/lib/klee_byte_buf_helper.c
@@ -63,3 +63,11 @@ void ensure_byte_buf_has_allocated_buffer_member(
 bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf) {
     return (buf->allocator == sea_allocator());
 }
+
+bool byte_bufs_are_equal(struct aws_byte_buf *b1, struct aws_byte_buf *b2) {
+  if (!b1 || !b2)
+    return b1 == b2;
+
+  return b1->len == b2->len && b1->buffer == b2->buffer &&
+         b1->capacity == b2->capacity && b1->allocator == b2->allocator;
+}

--- a/seahorn/lib/klee_ring_buffer_helper.c
+++ b/seahorn/lib/klee_ring_buffer_helper.c
@@ -1,0 +1,76 @@
+#include <ring_buffer_helper.h>
+#include <nondet.h>
+#include <proof_allocators.h>
+#include <seahorn/seahorn.h>
+
+#include <aws/common/byte_buf.h>
+
+void initialize_ring_buffer(struct aws_ring_buffer *ring_buf,
+                            const size_t size) {
+  ring_buf->allocator = sea_allocator();
+  /* The `aws_ring_buffer_init` function requires size > 0. */
+  assume(0 < size && size <= KLEE_MAX_SIZE);
+  ring_buf->allocation = bounded_malloc(size);
+  size_t position_head = nd_size_t();
+  size_t position_tail = nd_size_t();
+  assume(position_head < size);
+  assume(position_tail < size);
+  aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
+  aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
+  uint8_t *head = (uint8_t *)aws_atomic_load_ptr(&ring_buf->head);
+  uint8_t *tail = (uint8_t *)aws_atomic_load_ptr(&ring_buf->tail);
+  /* if head points-to the first element of the buffer then tail must too */
+  assume((head != ring_buf->allocation) || (tail == ring_buf->allocation));
+  ring_buf->allocation_end = ring_buf->allocation + size;
+}
+
+void ensure_byte_buf_has_allocated_buffer_member_in_range(
+    struct aws_byte_buf *buf, uint8_t *lo, uint8_t *hi) {
+  sassert(lo < hi);
+  size_t space = hi - lo;
+  size_t pos = nd_size_t();
+  assume(pos < space);
+  buf->buffer = lo + pos;
+  size_t max_capacity = hi - buf->buffer;
+  sassert(0 < max_capacity);
+  assume(0 < buf->capacity && buf->capacity <= max_capacity);
+}
+
+void ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(
+    struct aws_byte_buf *buf, struct aws_ring_buffer *ring_buf) {
+  buf->allocator = nd_bool() ? NULL : sea_allocator();
+  uint8_t *head = aws_atomic_load_ptr(&ring_buf->head);
+  uint8_t *tail = aws_atomic_load_ptr(&ring_buf->tail);
+  if (head < tail) { /* [....H    T....] */
+    if (nd_bool()) {
+      assume(tail < ring_buf->allocation_end);
+      ensure_byte_buf_has_allocated_buffer_member_in_range(
+          buf, tail, ring_buf->allocation_end);
+    } else {
+      assume(ring_buf->allocation < head);
+      ensure_byte_buf_has_allocated_buffer_member_in_range(
+          buf, ring_buf->allocation, head);
+    }
+  } else { /* [    T....H    ] */
+    ensure_byte_buf_has_allocated_buffer_member_in_range(buf, tail, head);
+  }
+}
+
+bool ring_buffers_are_equal(struct aws_ring_buffer *r1,
+                            struct aws_ring_buffer *r2) {
+  if (!r1 || !r2)
+    return r1 == r2;
+
+  bool res = r1->allocator == r2->allocator &&
+             r1->allocation == r2->allocation &&
+             r1->allocation_end == r2->allocation_end;
+  if (!res)
+    return false;
+  uint8_t *r1_head = aws_atomic_load_ptr(&r1->head);
+  uint8_t *r1_tail = aws_atomic_load_ptr(&r1->tail);
+
+  uint8_t *r2_head = aws_atomic_load_ptr(&r2->head);
+  uint8_t *r2_tail = aws_atomic_load_ptr(&r2->tail);
+
+  return r1_head == r2_head && r1_tail == r2_tail;
+}


### PR DESCRIPTION
- add Klee works on calling uninterpreted predicate fn
  - byte_cursor_left_trim_pred
  - byte_cursor_right_trim_pred
  - byte_cursor_satisfies_pred
  - byte_cursor_trim_pred
- add missed assumption on linked list back harness
```
    Start 15: klee_ptr_eq_test
1/1 Test #15: klee_ptr_eq_test .................   Passed    0.62 sec
    Start 12: klee_round_up_to_power_of_two_test
1/1 Test #12: klee_round_up_to_power_of_two_test ...   Passed    0.65 sec
```
- add part of ring_buffer targets for klee
```
    Start 258: klee_ring_buffer_clean_up_test
1/4 Test #258: klee_ring_buffer_clean_up_test ........   Passed   12.37 sec
    Start 260: klee_ring_buffer_init_test
2/4 Test #260: klee_ring_buffer_init_test ............   Passed   13.45 sec
    Start 281: klee_ring_buffer_acquire_test
3/4 Test #281: klee_ring_buffer_acquire_test .........   Passed   61.05 sec
    Start 284: klee_ring_buffer_acquire_up_to_test
4/4 Test #284: klee_ring_buffer_acquire_up_to_test ...   Passed   65.79 sec
```
