### PR TITLE
Enable fuzzing for all byte_cursor jobs

### DIFF
--- a/seahorn/include/utils.h
+++ b/seahorn/include/utils.h
@@ -23,6 +23,18 @@ extern void klee_assume(uintptr_t condition);
 #define KLEE_ASSUME(X)
 #endif
 
+#ifdef __FUZZ__
+#define FUZZ_ASSUME(X) assume(X)
+#else
+#define FUZZ_ASSUME(X)
+#endif
+
+#ifdef __FUZZ__ // set upper bound of X to Y during fuzzing
+#define FUZZ_ASSUME_LT(X, Y) X %= Y
+#else
+#define FUZZ_ASSUME_LT(X, Y)
+#endif
+
 extern __declspec(noalias) void sea_printf(const char *format, ...);
 
 #define IMPLIES(a, b) (!(a) || (b))

--- a/seahorn/jobs/byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
+++ b/seahorn/jobs/byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
@@ -41,4 +41,5 @@ int main() {
     sassert(aws_byte_buf_is_valid(&buf));
     sassert(aws_byte_cursor_is_valid(&src));
     assert_byte_cursor_equivalence(&src, &src_old, &old_byte_from_src);
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_advance/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_advance/CMakeLists.txt
@@ -8,3 +8,5 @@ sea_add_unsat_test(byte_cursor_advance)
 sea_add_klee(byte_cursor_advance
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_advance_harness.c)
+
+sea_add_fuzz(byte_cursor_advance aws_byte_cursor_advance_harness.c)

--- a/seahorn/jobs/byte_cursor_advance_nospec/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_advance_nospec/CMakeLists.txt
@@ -4,3 +4,5 @@ add_executable(byte_cursor_advance_nospec
 sea_attach_bc_link(byte_cursor_advance_nospec)
 sea_add_unsat_test(byte_cursor_advance_nospec)
 
+sea_add_fuzz(byte_cursor_advance_nospec
+  aws_byte_cursor_advance_nospec_harness.c)

--- a/seahorn/jobs/byte_cursor_compare_lexical/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_compare_lexical/CMakeLists.txt
@@ -8,3 +8,6 @@ sea_add_unsat_test(byte_cursor_compare_lexical)
 sea_add_klee(byte_cursor_compare_lexical
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_compare_lexical_harness.c)
+
+sea_add_fuzz(byte_cursor_compare_lexical
+  aws_byte_cursor_compare_lexical_harness.c)

--- a/seahorn/jobs/byte_cursor_compare_lookup/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_compare_lookup/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_compare_lookup)
 sea_add_klee(byte_cursor_compare_lookup
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_compare_lookup_harness.c)
+
+sea_add_fuzz(byte_cursor_compare_lookup
+  aws_byte_cursor_compare_lookup_harness.c)

--- a/seahorn/jobs/byte_cursor_eq/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq/CMakeLists.txt
@@ -8,3 +8,5 @@ sea_add_unsat_test(byte_cursor_eq)
 sea_add_klee(byte_cursor_eq
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_harness.c)
+
+sea_add_fuzz(byte_cursor_eq aws_byte_cursor_eq_harness.c)

--- a/seahorn/jobs/byte_cursor_eq_byte_buf/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_byte_buf/CMakeLists.txt
@@ -8,3 +8,5 @@ sea_add_unsat_test(byte_cursor_eq_byte_buf)
 sea_add_klee(byte_cursor_eq_byte_buf
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_byte_buf_harness.c)
+
+sea_add_fuzz(byte_cursor_eq_byte_buf aws_byte_cursor_eq_byte_buf_harness.c)

--- a/seahorn/jobs/byte_cursor_eq_byte_buf_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_byte_buf_ignore_case/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_eq_byte_buf_ignore_case)
 sea_add_klee(byte_cursor_eq_byte_buf_ignore_case
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_byte_buf_ignore_case_harness.c)
+
+sea_add_fuzz(byte_cursor_eq_byte_buf_ignore_case
+  aws_byte_cursor_eq_byte_buf_ignore_case_harness.c)

--- a/seahorn/jobs/byte_cursor_eq_c_str/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_c_str/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_eq_c_str)
 sea_add_klee(byte_cursor_eq_c_str
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_c_str_harness.c)
+
+sea_add_fuzz(byte_cursor_eq_c_str
+  aws_byte_cursor_eq_c_str_harness.c)

--- a/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_eq_c_str_ignore_case)
 sea_add_klee(byte_cursor_eq_c_str_ignore_case
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_c_str_ignore_case_harness.c)
+
+sea_add_fuzz(byte_cursor_eq_c_str_ignore_case
+  aws_byte_cursor_eq_c_str_ignore_case_harness.c)

--- a/seahorn/jobs/byte_cursor_eq_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_ignore_case/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_eq_ignore_case)
 sea_add_klee(byte_cursor_eq_ignore_case
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_eq_ignore_case_harness.c)
+
+sea_add_fuzz(byte_cursor_eq_ignore_case
+  aws_byte_cursor_eq_ignore_case_harness.c)

--- a/seahorn/jobs/byte_cursor_from_array/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_from_array/CMakeLists.txt
@@ -8,3 +8,6 @@ sea_add_unsat_test(byte_cursor_from_array)
 sea_add_klee(byte_cursor_from_array
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_from_array_harness.c)
+
+sea_add_fuzz(byte_cursor_from_array
+  aws_byte_cursor_from_array_harness.c)

--- a/seahorn/jobs/byte_cursor_from_buf/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_from_buf/CMakeLists.txt
@@ -8,3 +8,6 @@ sea_add_unsat_test(byte_cursor_from_buf)
 sea_add_klee(byte_cursor_from_buf
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_from_buf_harness.c)
+
+sea_add_fuzz(byte_cursor_from_buf
+  aws_byte_cursor_from_buf_harness.c)

--- a/seahorn/jobs/byte_cursor_from_c_str/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_from_c_str/CMakeLists.txt
@@ -8,3 +8,6 @@ sea_add_unsat_test(byte_cursor_from_c_str)
 sea_add_klee(byte_cursor_from_c_str
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_from_c_str_harness.c)
+
+sea_add_fuzz(byte_cursor_from_c_str
+  aws_byte_cursor_from_c_str_harness.c)

--- a/seahorn/jobs/byte_cursor_from_string/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_from_string/CMakeLists.txt
@@ -11,3 +11,6 @@ sea_add_klee(byte_cursor_from_string
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   ${AWS_C_COMMON_ROOT}/source/string.c
   aws_byte_cursor_from_string_harness.c)
+
+sea_add_fuzz(byte_cursor_from_string
+  aws_byte_cursor_from_string_harness.c)

--- a/seahorn/jobs/byte_cursor_left_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_left_trim_pred/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_left_trim_pred)
 sea_add_klee(byte_cursor_left_trim_pred
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_left_trim_pred_harness.c)
+
+sea_add_fuzz(byte_cursor_left_trim_pred
+  aws_byte_cursor_left_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
@@ -6,7 +6,7 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
-#ifdef __KLEE__
+#if defined(__KLEE__) || defined(__FUZZ__)
 bool uninterpreted_predicate_fn(uint8_t value) {
     return nd_bool();
 }

--- a/seahorn/jobs/byte_cursor_read/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read/CMakeLists.txt
@@ -5,3 +5,4 @@ sea_attach_bc_link(byte_cursor_read)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read)
 
+sea_add_fuzz(byte_cursor_read aws_byte_cursor_read_harness.c)

--- a/seahorn/jobs/byte_cursor_read_and_fill_buffer/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read_and_fill_buffer/CMakeLists.txt
@@ -4,3 +4,6 @@ add_executable(byte_cursor_read_and_fill_buffer
 sea_attach_bc_link(byte_cursor_read_and_fill_buffer)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read_and_fill_buffer)
+
+sea_add_fuzz(byte_cursor_read_and_fill_buffer
+  aws_byte_cursor_read_and_fill_buffer_harness.c)

--- a/seahorn/jobs/byte_cursor_read_be16/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read_be16/CMakeLists.txt
@@ -5,3 +5,6 @@ sea_overlink_libraries(byte_cursor_read_be16 byte_cursor_advance_nospec_override
 sea_attach_bc_link(byte_cursor_read_be16)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read_be16)
+
+sea_add_fuzz(byte_cursor_read_be16
+  aws_byte_cursor_read_be16_harness.c)

--- a/seahorn/jobs/byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
@@ -43,4 +43,5 @@ int main() {
         sassert(cur.ptr == old_cur.ptr + 2);
         sassert(cur.len == old_cur.len - 2);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_read_be32/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read_be32/CMakeLists.txt
@@ -5,3 +5,6 @@ sea_overlink_libraries(byte_cursor_read_be32 byte_cursor_advance_nospec_override
 sea_attach_bc_link(byte_cursor_read_be32)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read_be32)
+
+sea_add_fuzz(byte_cursor_read_be32
+  aws_byte_cursor_read_be32_harness.c)

--- a/seahorn/jobs/byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
@@ -43,4 +43,5 @@ int main() {
         sassert(cur.ptr == old_cur.ptr + 4);
         sassert(cur.len == old_cur.len - 4);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_read_be64/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read_be64/CMakeLists.txt
@@ -5,3 +5,6 @@ sea_overlink_libraries(byte_cursor_read_be64 byte_cursor_advance_nospec_override
 sea_attach_bc_link(byte_cursor_read_be64)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read_be64)
+
+sea_add_fuzz(byte_cursor_read_be64
+  aws_byte_cursor_read_be64_harness.c)

--- a/seahorn/jobs/byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
@@ -43,4 +43,5 @@ int main() {
         sassert(cur.ptr == old_cur.ptr + 8);
         sassert(cur.len == old_cur.len - 8);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_read_u8/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_read_u8/CMakeLists.txt
@@ -5,3 +5,6 @@ sea_overlink_libraries(byte_cursor_read_u8 byte_cursor_advance_nospec_override.i
 sea_attach_bc_link(byte_cursor_read_u8)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_read_u8)
+
+sea_add_fuzz(byte_cursor_read_u8
+  aws_byte_cursor_read_u8_harness.c)

--- a/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -14,6 +14,7 @@ int main() {
     initialize_byte_cursor(&cur);
     size_t length = nd_size_t();
     assume(length >= 1);
+    assume(length < MAX_BUFFER_SIZE);
     uint8_t *dest = bounded_malloc(length);
 
     /* assumptions */
@@ -41,4 +42,5 @@ int main() {
         sassert(cur.ptr == old_cur.ptr + 1);
         sassert(cur.len == old_cur.len - 1);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -14,7 +14,7 @@ int main() {
     initialize_byte_cursor(&cur);
     size_t length = nd_size_t();
     assume(length >= 1);
-    assume(length < MAX_BUFFER_SIZE);
+    FUZZ_ASSUME_LT(length, MAX_BUFFER_SIZE);
     uint8_t *dest = bounded_malloc(length);
 
     /* assumptions */

--- a/seahorn/jobs/byte_cursor_right_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_right_trim_pred/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_right_trim_pred)
 sea_add_klee(byte_cursor_right_trim_pred
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_right_trim_pred_harness.c)
+
+sea_add_fuzz(byte_cursor_right_trim_pred
+  aws_byte_cursor_right_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
@@ -8,7 +8,7 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
-#ifdef __KLEE__
+#if defined(__KLEE__) || defined(__FUZZ__)
 bool uninterpreted_predicate_fn(uint8_t value) {
     return nd_bool();
 }
@@ -36,4 +36,5 @@ int main() {
     if (cur.len > 0) {
         assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_satisfies_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_satisfies_pred/CMakeLists.txt
@@ -9,3 +9,6 @@ sea_add_unsat_test(byte_cursor_satisfies_pred)
 sea_add_klee(byte_cursor_satisfies_pred
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_satisfies_pred_harness.c)
+
+sea_add_fuzz(byte_cursor_satisfies_pred
+  aws_byte_cursor_satisfies_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
@@ -8,7 +8,7 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
-#ifdef __KLEE__
+#if defined(__KLEE__) || defined(__FUZZ__)
 bool uninterpreted_predicate_fn(uint8_t value) {
     return nd_bool();
 }
@@ -35,4 +35,5 @@ int main() {
     if (cur.len > 0) {
         assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
     }
+    return 0;
 }

--- a/seahorn/jobs/byte_cursor_trim_pred/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_trim_pred/CMakeLists.txt
@@ -9,3 +9,5 @@ sea_add_unsat_test(byte_cursor_trim_pred)
 sea_add_klee(byte_cursor_trim_pred
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
   aws_byte_cursor_trim_pred_harness.c)
+
+sea_add_fuzz(byte_cursor_trim_pred aws_byte_cursor_trim_pred_harness.c)

--- a/seahorn/jobs/byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/seahorn/jobs/byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -8,7 +8,7 @@
 #include <byte_buf_helper.h>
 #include <utils.h>
 
-#ifdef __KLEE__
+#if defined __KLEE__ || defined __FUZZ__
 bool uninterpreted_predicate_fn(uint8_t value) {
     return nd_bool();
 }
@@ -36,4 +36,5 @@ int main() {
     if (cur.len > 0) {
         assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
     }
+    return 0;
 }


### PR DESCRIPTION
also added `FUZZ_ASSUME_LT` for expressing upper bound during fuzzing; it is more in line with techniques already used in helper init functions: instead of using `assume` and aborting execution early, take modulus s.t. upper bound is maintained.