### PR TITLE
Finalize adaptation of unit proofs for KLEE

### DIFF
--- a/.github/workflows/klee.yml
+++ b/.github/workflows/klee.yml
@@ -2,8 +2,10 @@
 name: KLEE CI
 # Controls when the action will run
 on:
-  push: # temporary allow CI working on push step
-    branches: klee
+  pull_request:
+    branches: master
+  push:
+    branches: master
   schedule:
     - cron: 0 0 * * *  # run every day at UTC 00:00
 

--- a/seahorn/jobs/hash_array_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/hash_array_ignore_case/CMakeLists.txt
@@ -5,3 +5,9 @@ add_executable(hash_array_ignore_case
 sea_attach_bc_link(hash_array_ignore_case)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_array_ignore_case)
+
+# klee
+sea_add_klee(hash_array_ignore_case
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_array_ignore_case_harness.c)

--- a/seahorn/jobs/hash_byte_cursor_ptr/CMakeLists.txt
+++ b/seahorn/jobs/hash_byte_cursor_ptr/CMakeLists.txt
@@ -5,3 +5,9 @@ add_executable(hash_byte_cursor_ptr
 sea_attach_bc_link(hash_byte_cursor_ptr)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_byte_cursor_ptr)
+
+# klee
+sea_add_klee(hash_byte_cursor_ptr
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_hash_byte_cursor_ptr_harness.c)

--- a/seahorn/jobs/hash_byte_cursor_ptr_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/hash_byte_cursor_ptr_ignore_case/CMakeLists.txt
@@ -5,3 +5,9 @@ add_executable(hash_byte_cursor_ptr_ignore_case
 sea_attach_bc_link(hash_byte_cursor_ptr_ignore_case)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_byte_cursor_ptr_ignore_case)
+
+# klee
+sea_add_klee(hash_byte_cursor_ptr_ignore_case
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  aws_hash_byte_cursor_ptr_ignore_case_harness.c)

--- a/seahorn/jobs/hash_c_string/CMakeLists.txt
+++ b/seahorn/jobs/hash_c_string/CMakeLists.txt
@@ -3,3 +3,8 @@ add_executable(hash_c_string
   aws_hash_c_string_harness.c)
 sea_attach_bc_link(hash_c_string)
 sea_add_unsat_test(hash_c_string)
+
+# klee
+sea_add_klee(hash_c_string
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_c_string_harness.c)

--- a/seahorn/jobs/hash_c_string/aws_hash_c_string_harness.c
+++ b/seahorn/jobs/hash_c_string/aws_hash_c_string_harness.c
@@ -16,6 +16,10 @@ int main(void) {
   size_t len;
   const char *str = ensure_c_str_is_nd_allocated_aligned(MAX_STRING_LEN, &len);
 
+  #ifdef __KLEE__
+    if (!str)
+      return 0;
+  #endif
   assume(aws_c_string_is_valid(str));
 
   uint64_t rval = aws_hash_c_string(str);

--- a/seahorn/jobs/hash_callback_c_str_eq/CMakeLists.txt
+++ b/seahorn/jobs/hash_callback_c_str_eq/CMakeLists.txt
@@ -7,3 +7,11 @@ add_executable(hash_callback_c_str_eq
 sea_attach_bc_link(hash_callback_c_str_eq)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_callback_c_str_eq)
+
+# klee
+sea_add_klee(hash_callback_c_str_eq
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/string.c
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_callback_c_str_eq_harness.c)

--- a/seahorn/jobs/hash_callback_c_str_eq/aws_hash_callback_c_str_eq_harness.c
+++ b/seahorn/jobs/hash_callback_c_str_eq/aws_hash_callback_c_str_eq_harness.c
@@ -39,6 +39,10 @@ int main(void) {
       nd_bool() ? str1
                 : ensure_c_str_is_nd_allocated(MAX_STRING_LEN, &str2_len);
 
+  #ifdef __KLEE__
+    if (!str1 || !str2)
+      return 0;
+  #endif
   assume(aws_c_string_is_valid(str1));
   assume(aws_c_string_is_valid(str2));
 

--- a/seahorn/jobs/hash_callback_string_destroy/CMakeLists.txt
+++ b/seahorn/jobs/hash_callback_string_destroy/CMakeLists.txt
@@ -6,3 +6,11 @@ add_executable(hash_callback_string_destroy
   aws_hash_callback_string_destroy_harness.c)
 sea_attach_bc_link(hash_callback_string_destroy)
 sea_add_unsat_test(hash_callback_string_destroy)
+
+# klee
+sea_add_klee(hash_callback_string_destroy
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/string.c
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_callback_string_destroy_harness.c)

--- a/seahorn/jobs/hash_callback_string_eq/CMakeLists.txt
+++ b/seahorn/jobs/hash_callback_string_eq/CMakeLists.txt
@@ -7,3 +7,11 @@ add_executable(hash_callback_string_eq
 sea_attach_bc_link(hash_callback_string_eq)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_callback_string_eq)
+
+# klee
+sea_add_klee(hash_callback_string_eq
+  ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/string.c
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_callback_string_eq_harness.c)

--- a/seahorn/jobs/hash_iter_begin/CMakeLists.txt
+++ b/seahorn/jobs/hash_iter_begin/CMakeLists.txt
@@ -10,3 +10,9 @@ sea_overlink_libraries(hash_iter_begin hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_iter_begin)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_iter_begin)
+
+# klee
+sea_add_klee(hash_iter_begin
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_iter_begin_harness.c)

--- a/seahorn/jobs/hash_iter_begin_done/CMakeLists.txt
+++ b/seahorn/jobs/hash_iter_begin_done/CMakeLists.txt
@@ -10,3 +10,9 @@ sea_overlink_libraries(hash_iter_begin_done hash_table_state_is_valid_override.i
 sea_attach_bc_link(hash_iter_begin_done)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_iter_begin_done)
+
+# klee
+sea_add_klee(hash_iter_begin_done
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_iter_begin_done_harness.c)

--- a/seahorn/jobs/hash_iter_done/CMakeLists.txt
+++ b/seahorn/jobs/hash_iter_done/CMakeLists.txt
@@ -8,3 +8,9 @@ sea_link_libraries(hash_iter_done hash_table.opt.ir)
 sea_overlink_libraries(hash_iter_done hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_iter_done)
 sea_add_unsat_test(hash_iter_done)
+
+# klee
+sea_add_klee(hash_iter_done
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_iter_done_harness.c)

--- a/seahorn/jobs/hash_iter_done/aws_hash_iter_done_harness.c
+++ b/seahorn/jobs/hash_iter_done/aws_hash_iter_done_harness.c
@@ -18,8 +18,13 @@ int main(void) {
 
   struct aws_hash_iter iter;
   mk_valid_aws_hash_iter(&iter, &map);
+  #ifdef __KLEE__
+  if (iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED)
+       return 0;
+  #else
   assume(iter.status == AWS_HASH_ITER_STATUS_DONE ||
          iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+  #endif
   enum aws_hash_iter_status old_status = iter.status;
   struct store_byte_from_buffer old_byte;
   save_byte_from_hash_table(&map, &old_byte);

--- a/seahorn/jobs/hash_iter_next/CMakeLists.txt
+++ b/seahorn/jobs/hash_iter_next/CMakeLists.txt
@@ -10,3 +10,9 @@ sea_overlink_libraries(hash_iter_next hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_iter_next)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_iter_next)
+
+# klee
+sea_add_klee(hash_iter_next
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_iter_next_harness.c)

--- a/seahorn/jobs/hash_iter_next/aws_hash_iter_next_harness.c
+++ b/seahorn/jobs/hash_iter_next/aws_hash_iter_next_harness.c
@@ -26,8 +26,13 @@ int main(void) {
   aws_hash_iter_next(&iter);
 
   sassert(aws_hash_iter_is_valid(&iter));
-  sassert(iter.status == AWS_HASH_ITER_STATUS_DONE ||
-          iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+  #ifdef __KLEE__
+  if (iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED)
+       return 0;
+  #else
+  assume(iter.status == AWS_HASH_ITER_STATUS_DONE ||
+         iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+  #endif
   sassert(IMPLIES(old_status == AWS_HASH_ITER_STATUS_DONE,
                   iter.status == AWS_HASH_ITER_STATUS_DONE));
   sassert(aws_hash_table_is_valid(&map));

--- a/seahorn/jobs/hash_ptr/CMakeLists.txt
+++ b/seahorn/jobs/hash_ptr/CMakeLists.txt
@@ -3,3 +3,8 @@ add_executable(hash_ptr
   aws_hash_ptr_harness.c)
 sea_attach_bc_link(hash_ptr)
 sea_add_unsat_test(hash_ptr)
+
+# klee
+sea_add_klee(hash_ptr
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_ptr_harness.c)

--- a/seahorn/jobs/hash_string/CMakeLists.txt
+++ b/seahorn/jobs/hash_string/CMakeLists.txt
@@ -4,3 +4,9 @@ add_executable(hash_string
   aws_hash_string_harness.c)
 sea_attach_bc_link(hash_string)
 sea_add_unsat_test(hash_string)
+
+# klee
+sea_add_klee(hash_string
+  ${AWS_C_COMMON_ROOT}/source/string.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_string_harness.c)

--- a/seahorn/jobs/hash_table_clean_up/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_clean_up/CMakeLists.txt
@@ -9,3 +9,9 @@ sea_overlink_libraries(hash_table_clean_up hash_table_state_is_valid_override.ir
 sea_attach_bc_link(hash_table_clean_up)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_table_clean_up)
+
+# klee
+sea_add_klee(hash_table_clean_up
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_clean_up_harness.c)

--- a/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
+++ b/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
@@ -31,10 +31,14 @@ int main(void) {
 
   // this reads memory that has been freed, but we are not currently modelling
   // freeing memory
+  #ifdef __KLEE__
+    // klee does not allow to access memory after free.
+  #else
   size_t i = nd_size_t();
   size_t len = state->size * sizeof(state->slots[0]);
   assume(i < len);
   uint8_t *bytes = (uint8_t *)&state->slots[0];
   sassert(bytes[i] == 0);
+  #endif
   return 0;
 }

--- a/seahorn/jobs/hash_table_clear/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_clear/CMakeLists.txt
@@ -9,3 +9,9 @@ sea_overlink_libraries(hash_table_clear hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_clear)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_table_clear)
+
+# klee
+sea_add_klee(hash_table_clear
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_clear_harness.c)

--- a/seahorn/jobs/hash_table_eq/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_eq/CMakeLists.txt
@@ -10,3 +10,9 @@ sea_overlink_libraries(hash_table_eq hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_eq)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_table_eq)
+
+# klee
+sea_add_klee(hash_table_eq
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_eq_harness.c)

--- a/seahorn/jobs/hash_table_find/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_find/CMakeLists.txt
@@ -12,3 +12,9 @@ sea_overlink_libraries(hash_table_find hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_find)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_table_find)
+
+# klee
+sea_add_klee(hash_table_find
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_find_harness.c)

--- a/seahorn/jobs/hash_table_get_entry_count/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_get_entry_count/CMakeLists.txt
@@ -5,3 +5,9 @@ sea_link_libraries(hash_table_get_entry_count hash_table.opt.ir)
 sea_overlink_libraries(hash_table_get_entry_count hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_get_entry_count)
 sea_add_unsat_test(hash_table_get_entry_count)
+
+# klee
+sea_add_klee(hash_table_get_entry_count
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_get_entry_count_harness.c)

--- a/seahorn/jobs/hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
+++ b/seahorn/jobs/hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
@@ -10,9 +10,13 @@
 
 int main(void) {
   struct aws_hash_table table;
+  #ifdef __KLEE__
+  initialize_bounded_aws_hash_table(&table, MAX_TABLE_SIZE);
+  #else
   /* There are no loops in the code under test, so use the biggest possible
    * value */
   initialize_bounded_aws_hash_table(&table, SIZE_MAX);
+  #endif
   assume(aws_hash_table_is_valid(&table));
   struct hash_table_state *state = table.p_impl;
 

--- a/seahorn/jobs/hash_table_init_bounded/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_init_bounded/CMakeLists.txt
@@ -9,3 +9,9 @@ sea_overlink_libraries(hash_table_init_bounded hash_table_state_is_valid_overrid
 sea_attach_bc_link(hash_table_init_bounded)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(hash_table_init_bounded)
+
+# klee
+sea_add_klee(hash_table_init_bounded
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_init_bounded_harness.c)

--- a/seahorn/jobs/hash_table_init_unbounded/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_init_unbounded/CMakeLists.txt
@@ -7,3 +7,9 @@ sea_overlink_libraries(hash_table_init_unbounded update_template_size_override.i
 sea_overlink_libraries(hash_table_init_unbounded hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_init_unbounded)
 sea_add_unsat_test(hash_table_init_unbounded)
+
+# klee
+sea_add_klee(hash_table_init_unbounded
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_init_unbounded_harness.c)

--- a/seahorn/jobs/hash_table_move/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_move/CMakeLists.txt
@@ -4,3 +4,9 @@ sea_link_libraries(hash_table_move hash_table.opt.ir)
 sea_overlink_libraries(hash_table_move hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_move)
 sea_add_unsat_test(hash_table_move)
+
+# klee
+sea_add_klee(hash_table_move
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_move_harness.c)

--- a/seahorn/jobs/hash_table_move/aws_hash_table_move_harness.c
+++ b/seahorn/jobs/hash_table_move/aws_hash_table_move_harness.c
@@ -7,9 +7,13 @@ int main(void) {
   struct aws_hash_table to;
   struct aws_hash_table from;
 
+  #ifdef __KLEE__
+  initialize_bounded_aws_hash_table(&from, MAX_TABLE_SIZE);
+  #else
   // There are no loops in the code under test, so use the biggest possible
   // value
   initialize_bounded_aws_hash_table(&from, SIZE_MAX);
+  #endif
   assume(aws_hash_table_is_valid(&from));
 
   struct store_byte_from_buffer stored_byte;

--- a/seahorn/jobs/hash_table_swap/CMakeLists.txt
+++ b/seahorn/jobs/hash_table_swap/CMakeLists.txt
@@ -4,3 +4,9 @@ sea_link_libraries(hash_table_swap hash_table.opt.ir)
 sea_overlink_libraries(hash_table_swap hash_table_state_is_valid_override.ir)
 sea_attach_bc_link(hash_table_swap)
 sea_add_unsat_test(hash_table_swap)
+
+# klee
+sea_add_klee(hash_table_swap
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/hash_table.c
+  aws_hash_table_swap_harness.c)

--- a/seahorn/jobs/hash_table_swap/aws_hash_table_swap_harness.c
+++ b/seahorn/jobs/hash_table_swap/aws_hash_table_swap_harness.c
@@ -12,11 +12,23 @@ int main(void) {
   /* There are no loops in the code under test, so use the biggest possible
    * value */
   /* Seahorn: initializing both lhs and rhs since init is non det anyways */
+  #ifdef __KLEE__
+  initialize_bounded_aws_hash_table(&a, MAX_TABLE_SIZE);
+  #else
+  // There are no loops in the code under test, so use the biggest possible
+  // value
   initialize_bounded_aws_hash_table(&a, SIZE_MAX);
+  #endif
   assume(aws_hash_table_is_valid(&a));
   save_byte_from_hash_table(&a, &stored_byte_a);
 
+  #ifdef __KLEE__
+  initialize_bounded_aws_hash_table(&b, MAX_TABLE_SIZE);
+  #else
+  // There are no loops in the code under test, so use the biggest possible
+  // value
   initialize_bounded_aws_hash_table(&b, SIZE_MAX);
+  #endif
   assume(aws_hash_table_is_valid(&b));
   save_byte_from_hash_table(&b, &stored_byte_b);
 

--- a/seahorn/lib/CMakeLists.txt
+++ b/seahorn/lib/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
   utils.c
   klee_ring_buffer_helper.c
   klee_allocators.c
+  klee_hash_table_helper.c
   sea_allocators.c
   allocator_override.c
   sea_string.cc
@@ -55,6 +56,7 @@ add_library(
   nd_klee.c
   klee_switch.c
 )
+target_compile_definitions(sea_symex PRIVATE __KLEE__)
 sea_attach_bc(sea_symex)
 
 add_library(

--- a/seahorn/lib/klee_byte_buf_helper.c
+++ b/seahorn/lib/klee_byte_buf_helper.c
@@ -13,6 +13,7 @@
 #include <byte_buf_helper.h>
 #include <nondet.h>
 #include <proof_allocators.h>
+#include <sea_allocators.h>
 
 void initialize_byte_buf(struct aws_byte_buf *const buf) {
     size_t cap = nd_size_t();
@@ -35,6 +36,16 @@ void initialize_byte_cursor(struct aws_byte_cursor *const cursor) {
     size_t max_buffer_size = sea_max_buffer_size();
     cursor->ptr = can_fail_malloc(sizeof(*(cursor->ptr)) * max_buffer_size);
     if (cursor->ptr){
+        cursor->len = nd_size_t();
+        assume(cursor->len <= max_buffer_size);
+    }
+    else cursor->len = 0;
+}
+
+void initialize_byte_cursor_aligned(struct aws_byte_cursor *const cursor) {
+    size_t max_buffer_size = sea_max_buffer_size();
+    cursor->ptr = sea_malloc_aligned_havoc(sizeof(*(cursor->ptr)) * max_buffer_size);
+    if (cursor->ptr) {
         cursor->len = nd_size_t();
         assume(cursor->len <= max_buffer_size);
     }

--- a/seahorn/lib/klee_hash_table_helper.c
+++ b/seahorn/lib/klee_hash_table_helper.c
@@ -1,0 +1,164 @@
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+
+#include <seahorn/seahorn.h>
+
+#include <hash_table_helper.h>
+#include <proof_allocators.h>
+
+uint64_t nd_hash_fn(const void *key) {
+    return nd_uint64_t();
+}
+bool nd_hash_equals_fn(const void *a, const void *b){
+    return nd_bool();
+}
+void hash_proof_destroy_noop(void *p) {}
+void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
+                                       size_t max_table_entries) {
+  size_t num_entries = nd_size_t();
+  assume(num_entries >= 2);
+  assume(num_entries <= max_table_entries);
+  assume(aws_is_power_of_two(num_entries));
+
+  size_t required_bytes;
+  /* assume setting required_bytes is successful */
+  assume(hash_table_state_required_bytes(num_entries, &required_bytes) ==
+         AWS_OP_SUCCESS);
+  struct hash_table_state *impl = bounded_malloc(required_bytes);
+  impl->size = num_entries;
+  impl->mask = num_entries - 1;
+  impl->max_load_factor = 0.95;
+  impl->alloc = sea_allocator();
+  impl->hash_fn = &nd_hash_fn;
+  impl->equals_fn = &nd_hash_equals_fn;
+  impl->destroy_key_fn = &hash_proof_destroy_noop;
+  impl->destroy_value_fn = &hash_proof_destroy_noop;
+  impl->entry_count = nd_size_t();
+  impl->max_load = nd_size_t();
+  for (int idx = 0; idx < impl->size; ++idx)
+    impl->slots[idx].hash_code = nd_uint64_t();
+  // Preconditions adapted
+  assume(impl->entry_count <= impl->max_load);
+  assume(impl->max_load < impl->size);
+
+  map->p_impl = impl;
+}
+
+// klee requires function call with a concretize implementation
+enum aws_hash_iter_status nd_hash_iter_status() {
+    enum aws_hash_iter_status status = nd_int();
+    assume(status >= AWS_HASH_ITER_STATUS_DONE && 
+        status <= AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    return status;
+}
+
+void initialize_aws_hash_iter(struct aws_hash_iter *iter,
+                              struct aws_hash_table *map) {
+  iter->map = map;
+  iter->element.key = nd_voidp();
+  iter->element.value = nd_voidp();
+  iter->slot = nd_size_t();
+  iter->limit = nd_size_t();
+  assume(iter->limit <= iter->map->p_impl->size);
+  iter->status = nd_hash_iter_status();
+  if (iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
+      assume(iter->slot < iter->limit);
+      assume(map->p_impl->slots[iter->slot].hash_code > 0);
+  }
+}
+
+bool aws_hash_iter_is_valid_copy(const struct aws_hash_iter *iter) {
+    if (!iter) {
+        return false;
+    }
+    if (!iter->map) {
+        return false;
+    }
+    if (!aws_hash_table_is_valid(iter->map)) {
+        return false;
+    }
+    if (iter->limit > iter->map->p_impl->size) {
+        return false;
+    }
+
+    switch (iter->status) {
+        case AWS_HASH_ITER_STATUS_DONE:
+            /* Done iff slot == limit */
+            return iter->slot == iter->limit;
+        case AWS_HASH_ITER_STATUS_DELETE_CALLED:
+            /* iter->slot can underflow to SIZE_MAX after a delete
+             * see the comments for aws_hash_iter_delete() */
+            return iter->slot <= iter->limit || iter->slot == SIZE_MAX;
+        case AWS_HASH_ITER_STATUS_READY_FOR_USE:
+            /* A slot must point to a valid location (i.e. hash_code != 0) */
+            return iter->slot < iter->limit && iter->map->p_impl->slots[iter->slot].hash_code != 0;
+    }
+    /* Invalid status code */
+    return false;
+}
+
+void mk_valid_aws_hash_iter(struct aws_hash_iter *iter,
+                            struct aws_hash_table *map) {
+  initialize_aws_hash_iter(iter, map);
+  assume(aws_hash_iter_is_valid_copy(iter));
+}
+void save_byte_from_hash_table(const struct aws_hash_table *map,
+                               struct store_byte_from_buffer *storage) {
+  struct hash_table_state *state = map->p_impl;
+  size_t size_in_bytes;
+  assume(hash_table_state_required_bytes(state->size, &size_in_bytes) ==
+         AWS_OP_SUCCESS);
+  save_byte_from_array((uint8_t *)state, size_in_bytes, storage);
+}
+
+void assert_hash_table_unchanged(const struct aws_hash_table *map,
+                                 const struct store_byte_from_buffer *storage) {
+  struct hash_table_state *state = map->p_impl;
+  uint8_t *byte_array = (uint8_t *)state;
+  assert_byte_from_buffer_matches((uint8_t *)state, storage);
+}
+
+void ensure_hash_table_has_valid_destroy_functions(struct aws_hash_table *map) {
+  map->p_impl->destroy_key_fn = nd_bool() ? NULL : hash_proof_destroy_noop;
+  map->p_impl->destroy_value_fn = nd_bool() ? NULL : hash_proof_destroy_noop;
+}
+
+bool hash_table_state_has_an_empty_slot(
+    const struct hash_table_state *const state, size_t *const rval) {
+  assume(state->entry_count > 0);
+  size_t empty_slot_idx = nd_size_t();
+  assume(empty_slot_idx < state->size);
+  *rval = empty_slot_idx;
+  return state->slots[empty_slot_idx].hash_code == 0;
+}
+
+bool aws_hash_table_has_an_empty_slot(const struct aws_hash_table *const map,
+                                      size_t *const rval) {
+  return hash_table_state_has_an_empty_slot(map->p_impl, rval);
+}
+
+size_t aws_hash_table_deep_entry_count(const struct aws_hash_table *const map) {
+  struct hash_table_state *state = map->p_impl;
+  size_t rval = 0;
+  for (size_t i = 0; i < state->size; i++) {
+    struct hash_table_entry *entry = &state->slots[i];
+    if (entry->hash_code){
+      rval++;
+    }
+  }
+  return rval;
+}
+
+bool aws_hash_table_entry_count_is_valid(const struct aws_hash_table *const map) {
+  return map->p_impl->entry_count == aws_hash_table_deep_entry_count(map);
+}
+
+bool aws_hash_table_deep_is_empty(const struct aws_hash_table *const map) {
+  struct hash_table_state *state = map->p_impl;
+  bool rval = true;
+  for (size_t i = 0; i < state->size; i++) {
+    struct hash_table_entry *entry = &state->slots[i];
+    rval = rval && (entry->hash_code == 0);
+  }
+  return rval;
+}

--- a/seahorn/lib/klee_string_helper.c
+++ b/seahorn/lib/klee_string_helper.c
@@ -1,5 +1,7 @@
+#include <bounds.h>
 #include <proof_allocators.h>
 #include <string_helper.h>
+#include <sea_allocators.h>
 #include <seahorn/seahorn.h>
 
 struct aws_string *ensure_string_is_allocated(size_t len) {
@@ -29,6 +31,18 @@ struct aws_string *ensure_string_is_allocated_nondet_length(void) {
    */
   return ensure_string_is_allocated_bounded_length(KLEE_MAX_STRING_SIZE - 1 -
                                                    sizeof(struct aws_string));
+}
+
+// This takes in a ptr to an allocated piece of memory with the desired
+// string len and initializes the string.
+static void sea_init_str(char *str, size_t str_len) {
+  str[str_len] = '\0';
+  size_t max_string_len = sea_max_string_len();
+  for (size_t j = 0; j < max_string_len; j++) {
+    if (j < str_len) {
+      assume(str[j] != '\0');
+    }
+  }
 }
 
 static const char *_ensure_c_str_is_nd_allocated(size_t max_size, size_t *len,
@@ -61,9 +75,36 @@ static const char *_ensure_c_str_is_nd_allocated(size_t max_size, size_t *len,
     return str;
 }
 
+static const char *
+_ensure_c_str_is_nd_allocated_aligned(size_t max_size, size_t *len, bool safe) {
+  size_t alloc_size;
+  alloc_size = nd_size_t();
+  // allocate no more than sea_max_string_len() + 1
+  assume(alloc_size > 0);
+  assume(alloc_size <= max_size);
+  assume(max_size <= sea_max_string_len());
+
+  // this allocation never fails
+  char *str;
+  str = sea_malloc_aligned_havoc(alloc_size);
+  if (safe)
+    assume(str);
+  if (!str)
+    return NULL;
+
+  sea_init_str(str, alloc_size - 1);
+  *len = alloc_size - 1;
+  return str;
+}
+
 // This can return a NULL ptr. len will be zero in this case.
 const char *ensure_c_str_is_nd_allocated(size_t max_size, size_t *len) {
   return _ensure_c_str_is_nd_allocated(max_size, len, false);
+}
+
+// This can return a NULL ptr. len will be zero in this case.
+const char *ensure_c_str_is_nd_allocated_aligned(size_t max_size, size_t *len) {
+  return _ensure_c_str_is_nd_allocated_aligned(max_size, len, false);
 }
 
 /** Allocate a randomly initialized string with a range of maximal length


### PR DESCRIPTION
Two major commits:

1. Made KLEE's adaptation on `hash` and `hash_table` categories. The `hash_table` category is not fully covered due to KLEE's analysis timeout (even use our own stubs). The not covered targets are `hash_iter_delete`, `hash_table_create`, `hash_table_foreach*`, `hash_table_put`, and `hash_table_remove`.
2. Switched CI workflow into master branch.

The running times on each worked harness:
```
    Start 168: klee_hash_ptr_test
 1/22 Test #168: klee_hash_ptr_test ...........................   Passed    0.54 sec
      Start 170: klee_hash_string_test
 2/22 Test #170: klee_hash_string_test ........................   Passed   12.70 sec
      Start 172: klee_hash_array_ignore_case_test
 3/22 Test #172: klee_hash_array_ignore_case_test .............   Passed   13.86 sec
      Start 174: klee_hash_byte_cursor_ptr_test
 4/22 Test #174: klee_hash_byte_cursor_ptr_test ...............   Passed    0.69 sec
      Start 176: klee_hash_byte_cursor_ptr_ignore_case_test
 5/22 Test #176: klee_hash_byte_cursor_ptr_ignore_case_test ...   Passed    0.72 sec
      Start 178: klee_hash_c_string_test
 6/22 Test #178: klee_hash_c_string_test ......................   Passed    1.89 sec
      Start 180: klee_hash_callback_string_eq_test
 7/22 Test #180: klee_hash_callback_string_eq_test ............   Passed   60.85 sec
      Start 182: klee_hash_callback_c_str_eq_test
 8/22 Test #182: klee_hash_callback_c_str_eq_test .............   Passed   84.32 sec
      Start 184: klee_hash_callback_string_destroy_test
 9/22 Test #184: klee_hash_callback_string_destroy_test .......   Passed   15.05 sec
      Start 186: klee_hash_iter_begin_test
10/22 Test #186: klee_hash_iter_begin_test ....................   Passed   15.85 sec
      Start 188: klee_hash_iter_begin_done_test
11/22 Test #188: klee_hash_iter_begin_done_test ...............   Passed   16.03 sec
      Start 190: klee_hash_iter_next_test
12/22 Test #190: klee_hash_iter_next_test .....................   Passed   29.47 sec
      Start 192: klee_hash_iter_done_test
13/22 Test #192: klee_hash_iter_done_test .....................   Passed   16.17 sec
      Start 195: klee_hash_table_eq_test
14/22 Test #195: klee_hash_table_eq_test ......................   Passed  1051.39 sec
      Start 197: klee_hash_table_get_entry_count_test
15/22 Test #197: klee_hash_table_get_entry_count_test .........   Passed   15.54 sec
      Start 199: klee_hash_table_move_test
16/22 Test #199: klee_hash_table_move_test ....................   Passed   15.83 sec
      Start 201: klee_hash_table_swap_test
17/22 Test #201: klee_hash_table_swap_test ....................   Passed   35.04 sec
      Start 203: klee_hash_table_clean_up_test
18/22 Test #203: klee_hash_table_clean_up_test ................   Passed   60.88 sec
      Start 205: klee_hash_table_clear_test
19/22 Test #205: klee_hash_table_clear_test ...................   Passed   68.40 sec
    Start 210: klee_hash_table_find_test
20/22 Test #210: klee_hash_table_find_test ....................   Passed   31.33 sec
    Start 212: klee_hash_table_init_bounded_test
21/22 Test #212: klee_hash_table_init_bounded_test ............   Passed    0.61 sec
    Start 214: klee_hash_table_init_unbounded_test
22/22 Test #214: klee_hash_table_init_unbounded_test ..........   Passed    0.56 sec
```