### PR TITLE
fix(jobs): add word size one config for memcpy

### DIFF
--- a/seahorn/jobs/array_list_pop_front/CMakeLists.txt
+++ b/seahorn/jobs/array_list_pop_front/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(array_list_pop_front
   ${AWS_C_COMMON_ROOT}/source/array_list.c
   aws_array_list_pop_front_harness.c)
 sea_attach_bc_link(array_list_pop_front)
+configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(array_list_pop_front)
 
 # klee

--- a/seahorn/jobs/array_list_pop_front/sea.yaml
+++ b/seahorn/jobs/array_list_pop_front/sea.yaml
@@ -1,0 +1,2 @@
+verify_options:
+  horn-bv2-word-size: 1


### PR DESCRIPTION
Add `sea.yaml` file to configure word size to fix the following error:
```
Error: unsupported memcpy due to size and/or alignment.
Warning: Interpreting memcpy as noop
```