### PR TITLE
feat(scripts): custom flags for experiment data script

### DIFF
--- a/scripts/get_exper_res.py
+++ b/scripts/get_exper_res.py
@@ -8,7 +8,7 @@ import argparse
 
 BUILDABSPATH = os.path.abspath('../build/')
 DATAABSPATH = os.path.abspath('../') + "/data"
-SEAHORN_ROOT = '../../seahorn'  # Put your seahorn root dir here
+SEAHORN_ROOT = '../../seahorn/build/run'  # Put your seahorn root dir here
 FILE_DICT = {
     "": "seahorn.csv",
     "--vac": "seahorn(vac).csv",
@@ -62,31 +62,45 @@ def collect_res_from_ctest(file_name):
     read_data_from_xml(res_data)
     write_data_into_csv(
         "{dir}/{file}".format(dir="../data", file=file_name), res_data)
+    print("Done, find result csv file at: %s" % file_name)
+
+def extra_to_filename(extra):
+    '''extra: --a=b --c=d to filename: a.b.c.d.csv'''
+    if (len(extra) == 0):
+        return 'base.csv'
+    parts = []
+    for flag in extra:
+        if flag.startswith('--'):
+            flag = flag[2:]
+        parts.extend(flag.split('='))
+    return f'{"_".join(parts)}.csv'
 
 
 def run_ctest_for_seahorn():
-    env_lst = ["", "--vac", "--horn-bmc-solver=smt-y2",
-               "--cex", "--cex --horn-bmc-solver=smt-y2"]
+    # env_lst = ["", "--horn-bmc-solver=smt-y2"]
     print("Start making SeaHorn results...")
-    for verify_flag in env_lst:
-        print(f'Run SeaHorn with config: {verify_flag} ')
-        set_env = f'env VERIFY_FLAGS={verify_flag}'
-        cmake_conf = make_new_cmake_conf(
-            "OFF", "ON" if args.bleed_edge else "OFF")
-        command_lst = ["rm -rf *", cmake_conf, "ninja",
-                       f'{set_env} ctest -D ExperimentalTest -R . --timeout 2000']
-        cddir = "cd " + BUILDABSPATH
-        for strcmd in command_lst:
-            cddir += " ; " + strcmd
-        if args.debug:
-            print(cddir)
-        process = subprocess.Popen(
-            '/bin/bash',
-            shell=True,
-            stdin=subprocess.PIPE,
-            stdout=get_output_level())
-        _ = process.communicate(cddir.encode())
-        collect_res_from_ctest(FILE_DICT[verify_flag])
+    # for verify_flag in env_lst:
+    set_env = ''
+    if extra and len(extra) > 0:
+        verify_flags = " ".join(extra)
+        print(f'Run SeaHorn with extra configs: {verify_flags} ')
+        set_env = f'env VERIFY_FLAGS=\"{verify_flags}\"'
+    cmake_conf = make_new_cmake_conf(
+        "OFF", "ON" if args.bleed_edge else "OFF")
+    command_lst = ["rm -rf *", cmake_conf, "ninja",
+        f'{set_env} ctest -j{os.cpu_count()} -D ExperimentalTest -R . --timeout {args.timeout}']
+    cddir = "cd " + BUILDABSPATH
+    for strcmd in command_lst:
+        cddir += " ; " + strcmd
+    if args.debug:
+        print(cddir)
+    process = subprocess.Popen(
+        '/bin/bash',
+        shell=True,
+        stdin=subprocess.PIPE,
+        stdout=get_output_level())
+    _ = process.communicate(cddir.encode())
+    collect_res_from_ctest(extra_to_filename(extra))
 
 
 def run_ctest_for_klee():
@@ -125,7 +139,9 @@ if __name__ == "__main__":
     parser.add_argument('--klee', action='store_true', default=False)
     parser.add_argument('--bleed_edge', action='store_true', default=False)
     parser.add_argument('--debug', action='store_true', default=False)
-    args = parser.parse_args()
+    parser.add_argument('--timeout', type=int, default=2000,
+        help='Seconds before timeout for each test')
+    args, extra = parser.parse_known_args()
     if args.klee:
         args.seahorn = False
     main()


### PR DESCRIPTION
Updated `get_exper_res.py` script such that experimenters can use any combination of `sea` flags when running the script to batch collect data.

Example usage: `python3 ../scripts/get_exper_res.py --seahorn --horn-bmc-solver=smt-y2 --horn-bv2-lambdas=false --timeout=600`

yes, user can also set timeout for ctest per job

Some example data can also be found [in this repo](https://github.com/danblitzhou/sea-bmc-datadump) as a makeshift solution