### PR TITLE
feat(lib): safety checks on memcpy and memmove

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ include(CTest)
 
 enable_testing()
 
+# Enables LLVM builtin functions for memory operations. We do not check these for memory safety.
+# To check for memory safety, set this option to OFF. Then our wrappers will be used instead that
+# check for memory safety and call builtin functions directly.
+option(SEA_LLVM_MEM_BUILTINS "Use LLVM builtins memcpy/memmove without memory safety checks" OFF)
+
 
 option(SEA_ENABLE_FUZZ "Enable fuzzing" OFF)
 option(SEA_WITH_BLEEDING_EDGE "Enable bleeding edge proofs" OFF)
@@ -16,15 +21,19 @@ option(SEA_ENABLE_SMACK "Enable SMACK" OFF)
 
 option(SEA_ALLOCATOR_CAN_FAIL "Use can fail allocator" OFF)
 
-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR )
-  message (FATAL_ERROR
-    "In-source builds are not allowed. Please clean your source tree and try again.")
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(
+    FATAL_ERROR
+    "In-source builds are not allowed. Please clean your source tree and try again."
+  )
 endif()
 
 # Default is release with debug info
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+  set(
+    CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE
+  )
 endif()
 
 if(SEA_ENABLE_SMACK)
@@ -35,13 +44,13 @@ endif()
 set(SEAHORN_ROOT "/usr" CACHE PATH "Path to SeaHorn installation")
 set(SEA_LINK "llvm-link" CACHE STRING "Path to llvm-link")
 set(LLVMIR_LINK ${SEA_LINK})
-set(SEA_OPT "${SEAHORN_ROOT}/bin/seaopt" CACHE STRING  "Path to seaopt binary")
-set(SEA_PP "${SEAHORN_ROOT}/bin/seapp" CACHE STRING  "Path to seapp binary")
+set(SEA_OPT "${SEAHORN_ROOT}/bin/seaopt" CACHE STRING "Path to seaopt binary")
+set(SEA_PP "${SEAHORN_ROOT}/bin/seapp" CACHE STRING "Path to seapp binary")
 set(LLVMIR_OPT ${SEA_OPT})
 
 set(AWS_C_COMMON_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/aws-c-common)
 
-if (SEA_ENABLE_FUZZ)
+if(SEA_ENABLE_FUZZ)
   find_package(aws-c-common REQUIRED)
 endif()
 
@@ -59,4 +68,3 @@ include_directories(seahorn/include)
 include_directories(aws-c-common/include)
 include_directories(${SEAHORN_ROOT}/include)
 add_subdirectory(seahorn)
-

--- a/seahorn/CMakeLists.txt
+++ b/seahorn/CMakeLists.txt
@@ -176,6 +176,10 @@ function(sea_attach_bc name)
   target_compile_options(${SOURCE_EXE} PUBLIC -Wno-macro-redefined)
   target_compile_options(${SOURCE_EXE} PUBLIC -g)
   target_compile_options(${SOURCE_EXE} PUBLIC -fdeclspec)
+  # do not override memcpy/memmove, we provide our own wrappers
+  if (NOT SEA_LLVM_MEM_BUILTINS)
+    target_compile_options(${SOURCE_EXE} PUBLIC -fno-builtin-memcpy -fno-builtin-memmove)
+  endif()
   set_property(TARGET ${SOURCE_EXE} PROPERTY EXCLUDE_FROM_ALL ON)
 
   target_compile_definitions(${SOURCE_EXE} PRIVATE __SEAHORN__)

--- a/seahorn/lib/bcmp.c
+++ b/seahorn/lib/bcmp.c
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <strings.h>
 
 #define INLINE __attribute__((always_inline))
@@ -80,4 +81,16 @@ INLINE void *__memcpy_chk(void *dest, const void *src, size_t len,
 INLINE void *__memset_chk(void *dest, int c, size_t len, size_t dstlen) {
   sassert(!(dstlen < len));
   return __builtin_memset(dest, c, len);
+}
+
+INLINE void* memmove(void *dst, const void *src, size_t len)  {
+  sassert(sea_is_dereferenceable(dst, len));
+  sassert(sea_is_dereferenceable(src, len));
+  return __builtin_memmove(dst, src, len);
+}
+
+INLINE void *memcpy(void *dst, const void *src, size_t len) {
+  sassert(sea_is_dereferenceable(dst, len));
+  sassert(sea_is_dereferenceable(src, len));
+  return __builtin_memcpy(dst, src, len);
 }


### PR DESCRIPTION
LLVM rewrites memcpy and memmove using its own intrinsics. SeaHorn assumes that
intrinsics are safe and does not check them for memory. It is assumed that
conversion to intrinsics will add memory checks (which does happen on some
platforms).

This commit achieves two things

 1. add clang options to no automatically lift memcpy/memmove into intrisics
 2. add our implementation of memcpy/memmove that check memory safety and then
   call intrinsics directly

The behaviour is controlled by the cmake option SEA_LLVM_MEM_BUILTINS

The default configuration is OFF that enables safety checks.