### PR TITLE
fix(jobs): externalize static functions for klee

### DIFF
--- a/seahorn/jobs/priority_queue_pop/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_pop/CMakeLists.txt
@@ -9,9 +9,16 @@ sea_attach_bc_link(priority_queue_pop)
 sea_add_unsat_test(priority_queue_pop)
 
 # klee
-sea_add_klee(priority_queue_pop
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_pop_harness.c)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_pop.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_pop_harness.c
+  )
+  target_compile_definitions(priority_queue_pop.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_pop.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_pop.klee)
+  sea_add_klee_test(priority_queue_pop)
+endif()
 
 sea_add_fuzz(priority_queue_pop aws_priority_queue_pop_harness.c)

--- a/seahorn/jobs/priority_queue_push/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_push/CMakeLists.txt
@@ -10,12 +10,17 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_push)
 
 # klee
-sea_add_klee(
-  priority_queue_push
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_push_harness.c
-)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_push.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_push_harness.c
+  )
+  target_compile_definitions(priority_queue_push.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_push.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_push.klee)
+  sea_add_klee_test(priority_queue_push)
+endif()
 
 sea_add_fuzz(
   priority_queue_push

--- a/seahorn/jobs/priority_queue_push_ref/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_push_ref/CMakeLists.txt
@@ -10,12 +10,17 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_push_ref)
 
 # klee
-sea_add_klee(
-  priority_queue_push_ref
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_push_ref_harness.c
-)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_push_ref.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_push_ref_harness.c
+  )
+  target_compile_definitions(priority_queue_push_ref.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_push_ref.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_push_ref.klee)
+  sea_add_klee_test(priority_queue_push_ref)
+endif()
 
 sea_add_fuzz(
   priority_queue_push_ref

--- a/seahorn/jobs/priority_queue_remove/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_remove/CMakeLists.txt
@@ -9,12 +9,17 @@ sea_attach_bc_link(priority_queue_remove)
 sea_add_unsat_test(priority_queue_remove)
 
 # klee
-sea_add_klee(
-  priority_queue_remove
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_remove_harness.c
-)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_remove.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_remove_harness.c
+  )
+  target_compile_definitions(priority_queue_remove.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_remove.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_remove.klee)
+  sea_add_klee_test(priority_queue_remove)
+endif()
 
 sea_add_fuzz(
   priority_queue_remove

--- a/seahorn/jobs/priority_queue_s_sift_down/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_sift_down/CMakeLists.txt
@@ -9,7 +9,14 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_s_sift_down)
 
 # klee
-sea_add_klee(priority_queue_s_sift_down
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_s_sift_down_harness.c)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_s_sift_down.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_s_sift_down_harness.c
+  )
+  target_compile_definitions(priority_queue_s_sift_down.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_s_sift_down.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_s_sift_down.klee)
+  sea_add_klee_test(priority_queue_s_sift_down)
+endif()

--- a/seahorn/jobs/priority_queue_s_sift_either/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_sift_either/CMakeLists.txt
@@ -9,7 +9,14 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_s_sift_either)
 
 # klee
-sea_add_klee(priority_queue_s_sift_either
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_s_sift_either_harness.c)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_s_sift_either.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_s_sift_either_harness.c
+  )
+  target_compile_definitions(priority_queue_s_sift_either.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_s_sift_either.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_s_sift_either.klee)
+  sea_add_klee_test(priority_queue_s_sift_either)
+endif()

--- a/seahorn/jobs/priority_queue_s_sift_up/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_sift_up/CMakeLists.txt
@@ -9,7 +9,14 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_s_sift_up)
 
 # klee
-sea_add_klee(priority_queue_s_sift_up
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_s_sift_up_harness.c)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_s_sift_up.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_s_sift_up_harness.c
+  )
+  target_compile_definitions(priority_queue_s_sift_up.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_s_sift_up.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_s_sift_up.klee)
+  sea_add_klee_test(priority_queue_s_sift_up)
+endif()

--- a/seahorn/jobs/priority_queue_s_swap/CMakeLists.txt
+++ b/seahorn/jobs/priority_queue_s_swap/CMakeLists.txt
@@ -7,7 +7,14 @@ configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(priority_queue_s_swap)
 
 # klee
-sea_add_klee(priority_queue_s_swap
-  ${AWS_C_COMMON_ROOT}/source/array_list.c
-  ${AWS_C_COMMON_ROOT}/source/priority_queue.c
-  aws_priority_queue_s_swap_harness.c)
+if(SEA_ENABLE_KLEE)
+  add_executable(
+    priority_queue_s_swap.klee
+    ${AWS_C_COMMON_ROOT}/source/array_list.c
+    aws_priority_queue_s_swap_harness.c
+  )
+  target_compile_definitions(priority_queue_s_swap.klee PRIVATE __KLEE__)
+  sea_link_libraries(priority_queue_s_swap.klee priority_queue.opt.ir)
+  klee_attach_bc_link(priority_queue_s_swap.klee)
+  sea_add_klee_test(priority_queue_s_swap)
+endif()


### PR DESCRIPTION
- externalize static function for priority queue functions started with `s_*`.

```
 1/15 Test #289: klee_priority_queue_init_static_test .....   Passed   40.96 sec
 2/15 Test #291: klee_priority_queue_init_dynamic_test ....   Passed   41.69 sec
 3/15 Test #287: klee_priority_queue_top_test .............   Passed   88.73 sec
 4/15 Test #293: klee_priority_queue_clean_up_test ........   Passed   89.06 sec
 5/15 Test #285: klee_priority_queue_capacity_test ........   Passed  101.13 sec
 6/15 Test #283: klee_priority_queue_size_test ............   Passed  101.64 sec
 7/15 Test #300: klee_priority_queue_s_swap_test ..........   Passed  110.74 sec
 8/15 Test #302: klee_priority_queue_s_sift_up_test .......   Passed  111.85 sec
 9/15 Test #306: klee_priority_queue_s_sift_either_test ...   Passed   88.34 sec
10/15 Test #304: klee_priority_queue_s_sift_down_test .....   Passed  100.37 sec
11/15 Test #312: klee_priority_queue_pop_test .............   Passed   76.40 sec
12/15 Test #310: klee_priority_queue_remove_test ..........   Passed   92.78 sec
13/15 Test #308: klee_priority_queue_s_remove_node_test ...   Passed   93.25 sec
14/15 Test #316: klee_priority_queue_push_ref_test ........   Passed   74.40 sec
15/15 Test #314: klee_priority_queue_push_test ............   Passed   87.04 sec
```