### PR TITLE
fix(docker): update commands to install lastest cmake

### DIFF
--- a/docker/verify-c-common-fuzz.Dockerfile
+++ b/docker/verify-c-common-fuzz.Dockerfile
@@ -8,11 +8,8 @@ USER root
 ## Install latest cmake
 RUN apt -y remove --purge cmake
 RUN apt -y update
-RUN apt -y install wget
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN apt -y update
-RUN apt -y install cmake
+RUN apt -y install wget python3-pip
+RUN pip3 install cmake --upgrade
 
 # Install dependencies (Python and LLVM Cov Tools)
 RUN apt -y install python3

--- a/docker/verify-c-common-klee.Dockerfile
+++ b/docker/verify-c-common-klee.Dockerfile
@@ -7,11 +7,8 @@ USER root
 ## Install latest cmake
 RUN apt -y remove --purge cmake
 RUN apt -y update
-RUN apt -y install wget
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN apt -y update
-RUN apt -y install cmake
+RUN apt -y install wget python3-pip
+RUN pip3 install cmake --upgrade
 
 # Install lastest dependencies (LLVM-10)
 RUN apt -y install build-essential curl libcap-dev git \

--- a/docker/verify-c-common-smack.Dockerfile
+++ b/docker/verify-c-common-smack.Dockerfile
@@ -9,11 +9,8 @@ COPY --from=smack /home/usea/smack-toolchain /home/usea/smack-toolchain
 ## Install latest cmake
 RUN apt -y remove --purge cmake
 RUN apt -y update
-RUN apt -y install wget
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN apt -y update
-RUN apt -y install cmake
+RUN apt -y install wget python3-pip
+RUN pip3 install cmake --upgrade
 
 ## Install dotnet
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb

--- a/docker/verify-c-common.Dockerfile
+++ b/docker/verify-c-common.Dockerfile
@@ -9,11 +9,8 @@ USER root
 ## Install latest cmake
 RUN apt -y remove --purge cmake
 RUN apt -y update
-RUN apt -y install wget
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN apt -y update
-RUN apt -y install cmake
+RUN apt -y install wget python3-pip
+RUN pip3 install cmake --upgrade
 
 ## clone verify-c-common repository
 USER usea


### PR DESCRIPTION
Fixed the issue caused by adding Kitware APT Repository. Use an alternative way to install the latest CMake (version `3.21.3`).