### PR TITLE
fix: prevent ub, always havoc after malloc

### DIFF
--- a/seahorn/aws-c-common-stubs/s_expand_table_override.c
+++ b/seahorn/aws-c-common-stubs/s_expand_table_override.c
@@ -28,7 +28,7 @@ int s_expand_table(struct aws_hash_table *map) {
    * values for the entries */
   size_t required_bytes = sizeof(struct hash_table_state) +
                           template.size * sizeof(struct hash_table_entry);
-  struct hash_table_state *new_state = can_fail_malloc(required_bytes);
+  struct hash_table_state *new_state = can_fail_malloc_havoc(required_bytes);
 #else
   /* An empty slot has hashcode 0. So this marks all slots as empty */
   struct hash_table_state *new_state = s_alloc_state(&template);

--- a/seahorn/include/proof_allocators.h
+++ b/seahorn/include/proof_allocators.h
@@ -19,14 +19,14 @@ void *realloc(void *ptr, size_t new_size);
  * Deterministically allocates [size] bytes and returns a pointer;
  * memory allocated will be marked as containing non-det content using memhavoc
  */
-void *bounded_malloc(size_t size);
+void *bounded_malloc_havoc(size_t size);
 
 /**
  * Can non-deterministically fail;
  * if successful, allocate [size] bytes and returns a pointer;
  * memory allocated will be marked as containing non-det content using memhavoc
  */
-void *can_fail_malloc(size_t size);
+void *can_fail_malloc_havoc(size_t size);
 
 /**
  * Pointer to SeaHorn-based allocator

--- a/seahorn/jobs/array_eq/aws_array_eq_harness.c
+++ b/seahorn/jobs/array_eq/aws_array_eq_harness.c
@@ -11,7 +11,7 @@ int main() {
     /* assumptions */
     size_t lhs_len = nd_size_t();
     assume(lhs_len <= MAX_BUFFER_SIZE);
-    void *lhs = can_fail_malloc(lhs_len);
+    void *lhs = can_fail_malloc_havoc(lhs_len);
 
     #ifdef __KLEE__
         // The program path for a failed case which 
@@ -26,7 +26,7 @@ int main() {
         rhs = lhs;
     } else {
         assume(rhs_len <= MAX_BUFFER_SIZE);
-        rhs = can_fail_malloc(rhs_len);
+        rhs = can_fail_malloc_havoc(rhs_len);
     }
 
     #ifdef __KLEE__

--- a/seahorn/jobs/array_eq_c_str/aws_array_eq_c_str_harness.c
+++ b/seahorn/jobs/array_eq_c_str/aws_array_eq_c_str_harness.c
@@ -13,7 +13,7 @@ int main() {
   /* assumptions */
   size_t array_len = nd_size_t();
   assume(array_len <= MAX_BUFFER_SIZE);
-  uint8_t *array = bounded_malloc(array_len);
+  uint8_t *array = bounded_malloc_havoc(array_len);
 
   size_t str_len = 0;
   const char *c_str =

--- a/seahorn/jobs/array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
+++ b/seahorn/jobs/array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
@@ -13,7 +13,7 @@ int main() {
   /* assumptions */
   size_t array_len = nd_size_t();
   assume(array_len <= MAX_BUFFER_SIZE);
-  void *array = can_fail_malloc(MAX_BUFFER_SIZE);
+  void *array = can_fail_malloc_havoc(MAX_BUFFER_SIZE);
   size_t str_len = 0;
   const char *c_str =
       ensure_c_str_is_nd_allocated_safe(MAX_BUFFER_SIZE, &str_len);

--- a/seahorn/jobs/array_eq_ignore_case/aws_array_eq_ignore_case_harness.c
+++ b/seahorn/jobs/array_eq_ignore_case/aws_array_eq_ignore_case_harness.c
@@ -13,7 +13,7 @@ int main() {
     /* assumptions */
     size_t lhs_len = nd_size_t();
     assume(lhs_len <= MAX_BUFFER_SIZE);
-    void *lhs = bounded_malloc(lhs_len);
+    void *lhs = bounded_malloc_havoc(lhs_len);
 
     void *rhs;
     size_t rhs_len = nd_size_t();
@@ -22,7 +22,7 @@ int main() {
         rhs = lhs;
     } else {
         assume(rhs_len <= MAX_BUFFER_SIZE);
-        rhs = bounded_malloc(rhs_len);
+        rhs = bounded_malloc_havoc(rhs_len);
     }
 
     /* save current state of the parameters */

--- a/seahorn/jobs/array_list_back/aws_array_list_back_harness.c
+++ b/seahorn/jobs/array_list_back/aws_array_list_back_harness.c
@@ -15,7 +15,7 @@ int main() {
     initialize_bounded_array_list(&list);
 
     KLEE_ASSUME(list.item_size != 0);
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));

--- a/seahorn/jobs/array_list_front/aws_array_list_front_harness.c
+++ b/seahorn/jobs/array_list_front/aws_array_list_front_harness.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;

--- a/seahorn/jobs/array_list_get_at/aws_array_list_get_at_harness.c
+++ b/seahorn/jobs/array_list_get_at/aws_array_list_get_at_harness.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
     size_t index = nd_size_t();
 
     /* save current state of the data structure */

--- a/seahorn/jobs/array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/seahorn/jobs/array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void **val = bounded_malloc(sizeof(void *));
+    void **val = bounded_malloc_havoc(sizeof(void *));
     size_t index = nd_size_t();
 
     /* save current state of the data structure */

--- a/seahorn/jobs/array_list_init_static/aws_array_list_init_static_harness.c
+++ b/seahorn/jobs/array_list_init_static/aws_array_list_init_static_harness.c
@@ -38,7 +38,7 @@ int main() {
         assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
     #endif
     /* perform operation under verification */
-    uint8_t *raw_array = bounded_malloc(len);
+    uint8_t *raw_array = bounded_malloc_havoc(len);
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(raw_array, len, &old_byte);
 

--- a/seahorn/jobs/array_list_push_back/aws_array_list_push_back_harness.c
+++ b/seahorn/jobs/array_list_push_back/aws_array_list_push_back_harness.c
@@ -23,7 +23,7 @@ int main() {
     #else 
         assume(list.data != NULL);
     #endif
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;

--- a/seahorn/jobs/array_list_set_at/aws_array_list_set_at_harness.c
+++ b/seahorn/jobs/array_list_set_at/aws_array_list_set_at_harness.c
@@ -23,7 +23,7 @@ int main() {
     #else 
         assume(list.data != NULL);
     #endif
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
     size_t index = nd_size_t();
     KLEE_ASSUME(index <= KLEE_MAX_SIZE);
 

--- a/seahorn/jobs/byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/seahorn/jobs/byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -12,7 +12,7 @@ int main() {
     /* parameters */
     size_t length = nd_size_t();
     KLEE_ASSUME(length <= KLEE_MAX_SIZE);
-    uint8_t *array = bounded_malloc(length);
+    uint8_t *array = bounded_malloc_havoc(length);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_array(array, length);

--- a/seahorn/jobs/byte_buf_from_empty_array/aws_byte_buf_from_empty_array_harness.c
+++ b/seahorn/jobs/byte_buf_from_empty_array/aws_byte_buf_from_empty_array_harness.c
@@ -11,7 +11,7 @@
 int main() {
     size_t capacity = nd_size_t();
     KLEE_ASSUME(capacity <= KLEE_MAX_SIZE);
-    void *array = bounded_malloc(sizeof(*(array)) * (capacity));
+    void *array = bounded_malloc_havoc(sizeof(*(array)) * (capacity));
 
     struct aws_byte_buf buf = aws_byte_buf_from_empty_array(array, capacity);
     sassert(aws_byte_buf_is_valid(&buf));

--- a/seahorn/jobs/byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
+++ b/seahorn/jobs/byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
@@ -10,7 +10,7 @@
 
 int main() {
     /* data structure */
-    struct aws_byte_buf *dest = (struct aws_byte_buf *)bounded_malloc(sizeof(*dest));
+    struct aws_byte_buf *dest = (struct aws_byte_buf *)bounded_malloc_havoc(sizeof(*dest));
 
     /* parameters */
     struct aws_allocator *allocator = sea_allocator();

--- a/seahorn/jobs/byte_buf_write/aws_byte_buf_write_harness.c
+++ b/seahorn/jobs/byte_buf_write/aws_byte_buf_write_harness.c
@@ -14,7 +14,7 @@ int main() {
     initialize_byte_buf(&buf);
     size_t len = nd_size_t();
     assume (len <= MAX_BUFFER_SIZE);
-    uint8_t *array = bounded_malloc(MAX_BUFFER_SIZE);
+    uint8_t *array = bounded_malloc_havoc(MAX_BUFFER_SIZE);
 
     /* assumptions */
     assume(aws_byte_buf_is_valid(&buf));

--- a/seahorn/jobs/byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
+++ b/seahorn/jobs/byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
@@ -12,7 +12,7 @@ int main() {
     /* parameters */
     size_t length = nd_size_t();
     KLEE_ASSUME(length <= KLEE_MAX_SIZE);
-    uint8_t *array = bounded_malloc(length);
+    uint8_t *array = bounded_malloc_havoc(length);
 
     /* operation under verification */
     struct aws_byte_cursor cur = aws_byte_cursor_from_array(array, length);

--- a/seahorn/jobs/byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/seahorn/jobs/byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -14,7 +14,7 @@ int main() {
     initialize_byte_cursor(&cur);
     size_t length = nd_size_t();
     assume(length <= MAX_BUFFER_SIZE);
-    void *dest = bounded_malloc(length);
+    void *dest = bounded_malloc_havoc(length);
 
     /* assumptions */
     assume(aws_byte_cursor_is_valid(&cur));

--- a/seahorn/jobs/byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
@@ -12,7 +12,7 @@ int main() {
     /* parameters */
     struct aws_byte_cursor cur;
     initialize_byte_cursor(&cur);
-    uint16_t *dest = can_fail_malloc(sizeof(*dest));
+    uint16_t *dest = can_fail_malloc_havoc(sizeof(*dest));
 
     /* assumptions */
     assume(aws_byte_cursor_is_valid(&cur));

--- a/seahorn/jobs/byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
@@ -12,7 +12,7 @@ int main() {
     /* parameters */
     struct aws_byte_cursor cur;
     initialize_byte_cursor(&cur);
-    uint32_t *dest = can_fail_malloc(sizeof(*dest));
+    uint32_t *dest = can_fail_malloc_havoc(sizeof(*dest));
 
     /* assumptions */
     assume(aws_byte_cursor_is_valid(&cur));

--- a/seahorn/jobs/byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
+++ b/seahorn/jobs/byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
@@ -12,7 +12,7 @@ int main() {
     /* parameters */
     struct aws_byte_cursor cur;
     initialize_byte_cursor(&cur);
-    uint64_t *dest = can_fail_malloc(sizeof(*dest));
+    uint64_t *dest = can_fail_malloc_havoc(sizeof(*dest));
 
     /* assumptions */
     assume(aws_byte_cursor_is_valid(&cur));

--- a/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/seahorn/jobs/byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -15,7 +15,7 @@ int main() {
     size_t length = nd_size_t();
     assume(length >= 1);
     FUZZ_ASSUME_LT(length, MAX_BUFFER_SIZE);
-    uint8_t *dest = bounded_malloc(length);
+    uint8_t *dest = bounded_malloc_havoc(length);
 
     /* assumptions */
     assume(aws_byte_cursor_is_valid(&cur));

--- a/seahorn/jobs/hash_array_ignore_case/aws_hash_array_ignore_case_harness.c
+++ b/seahorn/jobs/hash_array_ignore_case/aws_hash_array_ignore_case_harness.c
@@ -7,7 +7,7 @@ int main(void) {
     /* parameters */
     size_t length = nd_size_t();
     assume(length < MAX_BUFFER_SIZE);
-    uint8_t *array = can_fail_malloc(length);
+    uint8_t *array = can_fail_malloc_havoc(length);
     assume(AWS_MEM_IS_READABLE(array, length));
 
     /* operation under verification */

--- a/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
+++ b/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
@@ -31,8 +31,9 @@ int main(void) {
 
   // this reads memory that has been freed, but we are not currently modelling
   // freeing memory
-  #ifdef __KLEE__
+  #if defined(__KLEE__) || defined(__FUZZ__)
     // klee does not allow to access memory after free.
+    // run-time UAF will be detected as by Address Sanitizer used by libFuzzer
   #else
   size_t i = nd_size_t();
   size_t len = state->size * sizeof(state->slots[0]);

--- a/seahorn/jobs/hash_table_foreach/aws_hash_table_foreach_harness.c
+++ b/seahorn/jobs/hash_table_foreach/aws_hash_table_foreach_harness.c
@@ -20,7 +20,10 @@ int main(void) {
   struct aws_hash_table map;
   initialize_bounded_aws_hash_table(&map, MAX_TABLE_SIZE);
   ensure_hash_table_has_valid_destroy_functions(&map);
-//   assume(aws_hash_table_entry_count_is_valid(&map));
+  #ifdef __FUZZ__
+  // otherwise pre-condition for deletion might fail
+  assume(aws_hash_table_entry_count_is_valid(&map));
+  #endif
   map.p_impl->equals_fn = nondet_equals;
   map.p_impl->hash_fn = uninterpreted_hasher;
   assume(aws_hash_table_is_valid(&map));

--- a/seahorn/jobs/priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
+++ b/seahorn/jobs/priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
@@ -27,7 +27,7 @@ int main(void) {
 
   /* perform operation under verification */
   #ifdef __KLEE__
-    uint8_t *raw_array = bounded_malloc(sizeof(uint8_t) * len);
+    uint8_t *raw_array = bounded_malloc_havoc(sizeof(uint8_t) * len);
     if (!raw_array) return 0; // assume(raw_array)
   #else 
     uint8_t *raw_array = sea_malloc_safe(sizeof(uint8_t) * len);

--- a/seahorn/jobs/priority_queue_init_static/aws_priority_queue_init_static_harness.c
+++ b/seahorn/jobs/priority_queue_init_static/aws_priority_queue_init_static_harness.c
@@ -32,7 +32,7 @@ int main(void) {
 
   /* perform operation under verification */
   #ifdef __KLEE__
-    raw_array = bounded_malloc(sizeof(uint8_t) * len);
+    raw_array = bounded_malloc_havoc(sizeof(uint8_t) * len);
     if (!raw_array) return 0; // assume(raw_array)
   #else 
     raw_array = sea_malloc_safe(sizeof(uint8_t) * len);

--- a/seahorn/jobs/priority_queue_pop/aws_priority_queue_pop_harness.c
+++ b/seahorn/jobs/priority_queue_pop/aws_priority_queue_pop_harness.c
@@ -27,7 +27,7 @@ int main() {
 
   /* Assume the function preconditions */
   assume(aws_priority_queue_is_valid(&queue));
-  void *item = can_fail_malloc(queue.container.item_size);
+  void *item = can_fail_malloc_havoc(queue.container.item_size);
   assume(item);
   assume(AWS_MEM_IS_WRITABLE(item, queue.container.item_size));
 
@@ -38,10 +38,10 @@ int main() {
     size_t len = queue.backpointers.length;
     if (0 < len) {
       ((struct aws_priority_queue_node **)queue.backpointers.data)[0] =
-          can_fail_malloc(sizeof(struct aws_priority_queue_node));
+          can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       if (0 != len - 1) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[len - 1] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
   }

--- a/seahorn/jobs/priority_queue_push/aws_priority_queue_push_harness.c
+++ b/seahorn/jobs/priority_queue_push/aws_priority_queue_push_harness.c
@@ -24,7 +24,7 @@ int main() {
   assume(aws_priority_queue_is_valid(&queue));
 
   /* Assumptions */
-  void *item = can_fail_malloc(queue.container.item_size);
+  void *item = can_fail_malloc_havoc(queue.container.item_size);
   assume(item);
   assume(AWS_MEM_IS_WRITABLE(item, queue.container.item_size));
 

--- a/seahorn/jobs/priority_queue_push_ref/aws_priority_queue_push_ref_harness.c
+++ b/seahorn/jobs/priority_queue_push_ref/aws_priority_queue_push_ref_harness.c
@@ -24,12 +24,12 @@ int main(void) {
   assume(aws_priority_queue_is_valid(&queue));
 
   /* Assumptions */
-  void *item = can_fail_malloc(queue.container.item_size);
+  void *item = can_fail_malloc_havoc(queue.container.item_size);
   assume(item);
   assume(AWS_MEM_IS_WRITABLE(item, queue.container.item_size));
 
   struct aws_priority_queue_node *backpointer =
-      can_fail_malloc(sizeof(struct aws_priority_queue_node));
+      can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
 
   /* Perform operation under verification */
   aws_priority_queue_push_ref(&queue, item, backpointer);

--- a/seahorn/jobs/priority_queue_remove/aws_priority_queue_remove_harness.c
+++ b/seahorn/jobs/priority_queue_remove/aws_priority_queue_remove_harness.c
@@ -27,11 +27,11 @@ int main() {
 
   /* Assume the function preconditions */
   assume(aws_priority_queue_is_valid(&queue));
-  void *item = can_fail_malloc(queue.container.item_size);
+  void *item = can_fail_malloc_havoc(queue.container.item_size);
   assume(item);
   assume(AWS_MEM_IS_WRITABLE(item, queue.container.item_size));
   struct aws_priority_queue_node *backpointer =
-      can_fail_malloc(sizeof(struct aws_priority_queue_node));
+      can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
   assume(backpointer);
   assume(AWS_MEM_IS_READABLE(backpointer, sizeof(struct aws_priority_queue_node)));
 
@@ -43,10 +43,10 @@ int main() {
     size_t len = queue.backpointers.length;
     if (index < len) {
       ((struct aws_priority_queue_node **)queue.backpointers.data)[index] =
-          can_fail_malloc(sizeof(struct aws_priority_queue_node));
+          can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       if (index != len - 1) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[len - 1] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
   }

--- a/seahorn/jobs/priority_queue_s_remove_node/aws_priority_queue_s_remove_node_harness.c
+++ b/seahorn/jobs/priority_queue_s_remove_node/aws_priority_queue_s_remove_node_harness.c
@@ -32,7 +32,7 @@ int main(void) {
   assume(index < queue.container.length);
 
   struct aws_priority_queue_node *node =
-      can_fail_malloc(sizeof(struct aws_priority_queue_node));
+      can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
 
   if (queue.backpointers.data) {
     /* Assume that the two backpointers index, len-1 are valid,
@@ -44,7 +44,7 @@ int main(void) {
           node;
       if (index != len - 1) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[len - 1] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
   }

--- a/seahorn/jobs/priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
+++ b/seahorn/jobs/priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
@@ -39,7 +39,7 @@ int main(void) {
     for (i = 0; i < MAX_PRIORITY_QUEUE_ITEMS; i++) {
       if (i < queue.container.length) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
 

--- a/seahorn/jobs/priority_queue_s_sift_either/aws_priority_queue_s_sift_either_harness.c
+++ b/seahorn/jobs/priority_queue_s_sift_either/aws_priority_queue_s_sift_either_harness.c
@@ -42,7 +42,7 @@ int main(void) {
     for (i = 0; i < MAX_PRIORITY_QUEUE_ITEMS; i++) {
       if (i < queue.container.length) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
 

--- a/seahorn/jobs/priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
+++ b/seahorn/jobs/priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
@@ -43,7 +43,7 @@ int main(void) {
     for (i = 0; i < MAX_PRIORITY_QUEUE_ITEMS; i++) {
       if (i < queue.container.length) {
         ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
-            can_fail_malloc(sizeof(struct aws_priority_queue_node));
+            can_fail_malloc_havoc(sizeof(struct aws_priority_queue_node));
       }
     }
 

--- a/seahorn/jobs/string_new_from_array/aws_string_new_from_array_harness.c
+++ b/seahorn/jobs/string_new_from_array/aws_string_new_from_array_harness.c
@@ -14,7 +14,7 @@ int main() {
     /* parameters */
     size_t alloc_size = nd_size_t();
     KLEE_ASSUME(alloc_size < MAX_STRING_LEN);
-    uint8_t *array = bounded_malloc(alloc_size);
+    uint8_t *array = bounded_malloc_havoc(alloc_size);
     struct aws_allocator *allocator = sea_allocator();
     size_t reported_size = nd_size_t();
 

--- a/seahorn/jobs2/array_eq2/aws_array_eq_harness2.c
+++ b/seahorn/jobs2/array_eq2/aws_array_eq_harness2.c
@@ -11,7 +11,7 @@ int main() {
     /* assumptions */
     size_t lhs_len = nd_size_t();
     assume(lhs_len <= MAX_BUFFER_SIZE);
-    void *lhs = can_fail_malloc(lhs_len);
+    void *lhs = can_fail_malloc_havoc(lhs_len);
 
     #ifdef __KLEE__
         // The program path for a failed case which 
@@ -26,7 +26,7 @@ int main() {
         rhs = lhs;
     } else {
         assume(rhs_len <= MAX_BUFFER_SIZE);
-        rhs = can_fail_malloc(rhs_len);
+        rhs = can_fail_malloc_havoc(rhs_len);
     }
 
     #ifdef __KLEE__

--- a/seahorn/jobs2/array_eq_c_str2/aws_array_eq_c_str_harness2.c
+++ b/seahorn/jobs2/array_eq_c_str2/aws_array_eq_c_str_harness2.c
@@ -13,7 +13,7 @@ int main() {
   /* assumptions */
   size_t array_len = nd_size_t();
   assume(array_len <= MAX_BUFFER_SIZE);
-  uint8_t *array = bounded_malloc(array_len);
+  uint8_t *array = bounded_malloc_havoc(array_len);
 
   size_t str_len = 0;
   const char *c_str =

--- a/seahorn/jobs2/array_eq_c_str_ignore_case2/aws_array_eq_c_str_ignore_case_harness2.c
+++ b/seahorn/jobs2/array_eq_c_str_ignore_case2/aws_array_eq_c_str_ignore_case_harness2.c
@@ -13,7 +13,7 @@ int main() {
   /* assumptions */
   size_t array_len = nd_size_t();
   assume(array_len <= MAX_BUFFER_SIZE);
-  void *array = can_fail_malloc(MAX_BUFFER_SIZE);
+  void *array = can_fail_malloc_havoc(MAX_BUFFER_SIZE);
   size_t str_len = 0;
   const char *c_str =
       ensure_c_str_is_nd_allocated_safe(MAX_BUFFER_SIZE, &str_len);

--- a/seahorn/jobs2/array_eq_ignore_case2/aws_array_eq_ignore_case_harness2.c
+++ b/seahorn/jobs2/array_eq_ignore_case2/aws_array_eq_ignore_case_harness2.c
@@ -13,7 +13,7 @@ int main() {
     /* assumptions */
     size_t lhs_len = nd_size_t();
     assume(lhs_len <= MAX_BUFFER_SIZE);
-    void *lhs = bounded_malloc(lhs_len);
+    void *lhs = bounded_malloc_havoc(lhs_len);
 
     void *rhs;
     size_t rhs_len = nd_size_t();
@@ -22,7 +22,7 @@ int main() {
         rhs = lhs;
     } else {
         assume(rhs_len <= MAX_BUFFER_SIZE);
-        rhs = bounded_malloc(rhs_len);
+        rhs = bounded_malloc_havoc(rhs_len);
     }
 
     /* save current state of the parameters */

--- a/seahorn/jobs2/array_list_back2/aws_array_list_back_harness2.c
+++ b/seahorn/jobs2/array_list_back2/aws_array_list_back_harness2.c
@@ -15,7 +15,7 @@ int main() {
     initialize_bounded_array_list(&list);
 
     KLEE_ASSUME(list.item_size != 0);
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));

--- a/seahorn/jobs2/array_list_front2/aws_array_list_front_harness2.c
+++ b/seahorn/jobs2/array_list_front2/aws_array_list_front_harness2.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;

--- a/seahorn/jobs2/array_list_get_at2/aws_array_list_get_at_harness2.c
+++ b/seahorn/jobs2/array_list_get_at2/aws_array_list_get_at_harness2.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
     size_t index = nd_size_t();
 
     /* save current state of the data structure */

--- a/seahorn/jobs2/array_list_get_at_ptr2/aws_array_list_get_at_ptr_harness2.c
+++ b/seahorn/jobs2/array_list_get_at_ptr2/aws_array_list_get_at_ptr_harness2.c
@@ -18,7 +18,7 @@ int main() {
 
     /* assumptions */
     assume(aws_array_list_is_valid(&list));
-    void **val = bounded_malloc(sizeof(void *));
+    void **val = bounded_malloc_havoc(sizeof(void *));
     size_t index = nd_size_t();
 
     /* save current state of the data structure */

--- a/seahorn/jobs2/array_list_init_static2/aws_array_list_init_static_harness2.c
+++ b/seahorn/jobs2/array_list_init_static2/aws_array_list_init_static_harness2.c
@@ -38,7 +38,7 @@ int main() {
         assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
     #endif
     /* perform operation under verification */
-    uint8_t *raw_array = bounded_malloc(len);
+    uint8_t *raw_array = bounded_malloc_havoc(len);
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(raw_array, len, &old_byte);
 

--- a/seahorn/jobs2/array_list_push_back2/aws_array_list_push_back_harness2.c
+++ b/seahorn/jobs2/array_list_push_back2/aws_array_list_push_back_harness2.c
@@ -23,7 +23,7 @@ int main() {
     #else 
         assume(list.data != NULL);
     #endif
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;

--- a/seahorn/jobs2/array_list_set_at2/aws_array_list_set_at_harness2.c
+++ b/seahorn/jobs2/array_list_set_at2/aws_array_list_set_at_harness2.c
@@ -23,7 +23,7 @@ int main() {
     #else 
         assume(list.data != NULL);
     #endif
-    void *val = bounded_malloc(list.item_size);
+    void *val = bounded_malloc_havoc(list.item_size);
     size_t index = nd_size_t();
     KLEE_ASSUME(index <= KLEE_MAX_SIZE);
 

--- a/seahorn/jobs2/byte_buf_init_copy2/aws_byte_buf_init_copy_harness2.c
+++ b/seahorn/jobs2/byte_buf_init_copy2/aws_byte_buf_init_copy_harness2.c
@@ -10,7 +10,7 @@
 
 int main() {
     /* data structure */
-    struct aws_byte_buf *dest = (struct aws_byte_buf *)bounded_malloc(sizeof(*dest));
+    struct aws_byte_buf *dest = (struct aws_byte_buf *)bounded_malloc_havoc(sizeof(*dest));
 
     /* parameters */
     struct aws_allocator *allocator = sea_allocator();

--- a/seahorn/jobs2/byte_buf_write2/aws_byte_buf_write_harness2.c
+++ b/seahorn/jobs2/byte_buf_write2/aws_byte_buf_write_harness2.c
@@ -14,7 +14,7 @@ int main() {
     initialize_byte_buf(&buf);
     size_t len = nd_size_t();
     assume (len <= MAX_BUFFER_SIZE);
-    uint8_t *array = bounded_malloc(MAX_BUFFER_SIZE);
+    uint8_t *array = bounded_malloc_havoc(MAX_BUFFER_SIZE);
 
     /* assumptions */
     assume(aws_byte_buf_is_valid(&buf));

--- a/seahorn/lib/allocator_override.c
+++ b/seahorn/lib/allocator_override.c
@@ -15,7 +15,7 @@
 void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
   (void)allocator;
   sassert(size != 0);
-  void *mem = can_fail_malloc(size);
+  void *mem = can_fail_malloc_havoc(size);
   if (!mem) {
     aws_raise_error(AWS_ERROR_OOM);
   }

--- a/seahorn/lib/array_list_helper.c
+++ b/seahorn/lib/array_list_helper.c
@@ -18,7 +18,7 @@ void initialize_array_list(struct aws_array_list *const list) {
   list->length = nd_size_t();
   list->item_size = nd_size_t();
   /// XXX Cannot do this for now
-  list->data = can_fail_malloc(list->current_size);
+  list->data = can_fail_malloc_havoc(list->current_size);
   list->alloc = sea_allocator();
 }
 
@@ -26,7 +26,7 @@ void initialize_bounded_array_list(struct aws_array_list *const list) {
   list->current_size = nd_size_t();
   list->item_size = nd_size_t();
   list->length = nd_size_t();
-  list->data = can_fail_malloc(list->current_size);
+  list->data = can_fail_malloc_havoc(list->current_size);
   list->alloc = sea_allocator();
   assume(aws_array_list_is_bounded(list, 
       sea_max_array_list_len(), sea_max_array_list_item_size()));

--- a/seahorn/lib/byte_buf_helper.c
+++ b/seahorn/lib/byte_buf_helper.c
@@ -23,7 +23,7 @@ void initialize_byte_buf(struct aws_byte_buf *const buf) {
 
     buf->len = len;
     buf->capacity = cap;
-    buf->buffer = can_fail_malloc(cap * sizeof(*(buf->buffer)));
+    buf->buffer = can_fail_malloc_havoc(cap * sizeof(*(buf->buffer)));
     buf->allocator = sea_allocator();
 }
 
@@ -31,7 +31,7 @@ void initialize_byte_cursor(struct aws_byte_cursor *const cursor) {
     cursor->len = nd_size_t();
     size_t max_buffer_size = sea_max_buffer_size();
     assume(cursor->len <= max_buffer_size);
-    cursor->ptr = can_fail_malloc(sizeof(*(cursor->ptr)) * max_buffer_size);
+    cursor->ptr = can_fail_malloc_havoc(sizeof(*(cursor->ptr)) * max_buffer_size);
 }
 
 void initialize_byte_cursor_aligned(struct aws_byte_cursor *const cursor) {
@@ -56,7 +56,7 @@ bool aws_byte_cursor_is_bounded(
 void ensure_byte_buf_has_allocated_buffer_member(
     struct aws_byte_buf *const buf) {
     buf->allocator = sea_allocator();
-    buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * sea_max_buffer_size());
+    buf->buffer = bounded_malloc_havoc(sizeof(*(buf->buffer)) * sea_max_buffer_size());
 }
 
 bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf) {

--- a/seahorn/lib/fuzz_allocators.c
+++ b/seahorn/lib/fuzz_allocators.c
@@ -10,9 +10,23 @@
 // for assume()
 #include <seahorn/seahorn.h> 
 
-void *bounded_malloc(size_t size) { return malloc(size); }
+// Note that for SEAHORN this function will always succeed in reserving memory
+// For fuzzing, this may fail.
+void *bounded_malloc_havoc(size_t size) {
+  void* data = malloc(size);
+  if (data) {
+    memhavoc(data, size);
+  }
+  return data;
+}
 
-void *can_fail_malloc(size_t size) { return malloc(size); }
+void *can_fail_malloc_havoc(size_t size) {
+  void* data = malloc(size);
+  if (data) {
+    memhavoc(data, size);
+  }
+  return data;
+}
 
 void *sea_malloc_safe(size_t sz) {
   void *p = malloc(sz);
@@ -42,7 +56,7 @@ void *sea_malloc_aligned_havoc(size_t sz) {
  */
 static void *s_malloc_allocator(struct aws_allocator *allocator, size_t size) {
   (void)allocator;
-  return bounded_malloc(size);
+  return bounded_malloc_havoc(size);
 }
 
 /**

--- a/seahorn/lib/fuzz_array_list_helper.c
+++ b/seahorn/lib/fuzz_array_list_helper.c
@@ -18,7 +18,7 @@ void initialize_array_list(struct aws_array_list *const list) {
   list->length = nd_size_t();
   list->item_size = nd_size_t();
   /// XXX Cannot do this for now
-  list->data = can_fail_malloc(list->current_size);
+  list->data = can_fail_malloc_havoc(list->current_size);
   list->alloc = sea_allocator();
 }
 
@@ -37,7 +37,7 @@ void initialize_bounded_array_list(struct aws_array_list *const list) {
 
   list->current_size = list->item_size * list->length;
 
-  list->data = (list->current_size == 0) ? NULL : can_fail_malloc(list->current_size);
+  list->data = (list->current_size == 0) ? NULL : can_fail_malloc_havoc(list->current_size);
   list->alloc = sea_allocator();
 }
 

--- a/seahorn/lib/fuzz_byte_buf_helper.c
+++ b/seahorn/lib/fuzz_byte_buf_helper.c
@@ -16,7 +16,7 @@ void initialize_byte_buf(struct aws_byte_buf *const buf) {
 
   buf->len = len;
   buf->capacity = cap;
-  buf->buffer = can_fail_malloc(cap * sizeof(*(buf->buffer)));
+  buf->buffer = can_fail_malloc_havoc(cap * sizeof(*(buf->buffer)));
   if (buf->buffer) {
     memhavoc(buf->buffer, cap * sizeof(*(buf->buffer)));
   }
@@ -28,7 +28,7 @@ void initialize_byte_cursor(struct aws_byte_cursor *const cursor) {
   cursor->len = nd_size_t();
   // cursor->len <= max_buffer_size
   cursor->len %= max_buffer_size;
-  cursor->ptr = can_fail_malloc(sizeof(*(cursor->ptr)) * max_buffer_size);
+  cursor->ptr = can_fail_malloc_havoc(sizeof(*(cursor->ptr)) * max_buffer_size);
 }
 
 void initialize_byte_cursor_aligned(struct aws_byte_cursor *const cursor) {

--- a/seahorn/lib/fuzz_hash_table_helper.c
+++ b/seahorn/lib/fuzz_hash_table_helper.c
@@ -125,9 +125,10 @@ void initialize_aws_hash_iter(struct aws_hash_iter *iter,
   iter->element.value = nd_voidp();
   iter->slot = nd_size_t();
   iter->limit = nd_size_t();
-  assume(iter->limit > 0);
-  // iter->limit <= iter->map->p_impl->size
+  // 0 < iter->limit <= iter->map->p_impl->size
   iter->limit %= iter->map->p_impl->size;
+  if (iter->limit == 0)
+    iter->limit = iter->map->p_impl->size;
   // iter->slot < iter->limit
   iter->slot %= iter->limit;
   iter->status = nd_hash_iter_status();

--- a/seahorn/lib/fuzz_hash_table_helper.c
+++ b/seahorn/lib/fuzz_hash_table_helper.c
@@ -30,7 +30,7 @@ void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
   /* assume setting required_bytes is successful */
   assume(hash_table_state_required_bytes(num_entries, &required_bytes) ==
          AWS_OP_SUCCESS);
-  struct hash_table_state *impl = bounded_malloc(required_bytes);
+  struct hash_table_state *impl = bounded_malloc_havoc(required_bytes);
   impl->size = num_entries;
   impl->mask = num_entries - 1;
   impl->max_load_factor = 0.95;
@@ -38,7 +38,7 @@ void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
   impl->hash_fn = &nd_hash_fn;
   impl->equals_fn = &nd_hash_equals_fn;
 #ifdef EXPLICIT_HASH_INIT
-  /** hash_table_state is implicitly initializaed by memhavoc() inside bounded_malloc() */
+  /** hash_table_state is implicitly initializaed by memhavoc() inside bounded_malloc_havoc() */
   impl->destroy_key_fn = &hash_proof_destroy_noop;
   impl->destroy_value_fn = &hash_proof_destroy_noop;
   impl->entry_count = nd_size_t();

--- a/seahorn/lib/fuzz_hash_table_helper.c
+++ b/seahorn/lib/fuzz_hash_table_helper.c
@@ -125,10 +125,11 @@ void initialize_aws_hash_iter(struct aws_hash_iter *iter,
   iter->element.value = nd_voidp();
   iter->slot = nd_size_t();
   iter->limit = nd_size_t();
+  assume(iter->limit > 0);
   // iter->limit <= iter->map->p_impl->size
   iter->limit %= iter->map->p_impl->size;
   // iter->slot < iter->limit
-  iter->slot %= (iter->limit - 1);
+  iter->slot %= iter->limit;
   iter->status = nd_hash_iter_status();
   if (iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
       // assume(map->p_impl->slots[iter->slot].hash_code > 0);

--- a/seahorn/lib/fuzz_ring_buffer_helper.c
+++ b/seahorn/lib/fuzz_ring_buffer_helper.c
@@ -13,7 +13,7 @@ void initialize_ring_buffer(struct aws_ring_buffer *ring_buf,
   // assume(size <= MAX_BUFFER_SIZE);
   size_t alloc_sz = size % MAX_BUFFER_SIZE;
 
-  ring_buf->allocation = bounded_malloc(alloc_sz);
+  ring_buf->allocation = bounded_malloc_havoc(alloc_sz);
   size_t position_head = nd_size_t();
   size_t position_tail = nd_size_t();
   assume(position_head < alloc_sz);

--- a/seahorn/lib/hash_table_helper.c
+++ b/seahorn/lib/hash_table_helper.c
@@ -19,7 +19,7 @@ void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
   /* assume setting required_bytes is successful */
   assume(hash_table_state_required_bytes(num_entries, &required_bytes) ==
          AWS_OP_SUCCESS);
-  struct hash_table_state *impl = bounded_malloc(required_bytes);
+  struct hash_table_state *impl = bounded_malloc_havoc(required_bytes);
   impl->size = num_entries;
   impl->mask = num_entries - 1;
   impl->max_load_factor = 0.95;
@@ -27,7 +27,7 @@ void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
   impl->hash_fn = &nd_hash_fn;
   impl->equals_fn = &nd_hash_equals_fn;
 #ifdef EXPLICIT_HASH_INIT
-  /** hash_table_state is implicitly initializaed by memhavoc() inside bounded_malloc() */
+  /** hash_table_state is implicitly initializaed by memhavoc() inside bounded_malloc_havoc() */
   impl->destroy_key_fn = &hash_proof_destroy_noop;
   impl->destroy_value_fn = &hash_proof_destroy_noop;
   impl->entry_count = nd_size_t();

--- a/seahorn/lib/klee_allocators.c
+++ b/seahorn/lib/klee_allocators.c
@@ -3,12 +3,18 @@
 #include <klee_switch.h>
 #include <nondet.h>
 
-void *bounded_malloc(size_t size) {
-  return size == 0 ? NULL : malloc(alloc_size(size));
+// Note this behaviour deviates from SEAHORN since this can fail to allocate
+// memory.
+void *bounded_malloc_havoc(size_t size) {
+  void* data = size == 0 ? NULL : malloc(alloc_size(size));
+  if (data) {
+    memhavoc(data, size);
+  }
+  return data;
 }
 
-void *can_fail_malloc(size_t size) { 
-    return nd_bool() ? NULL : bounded_malloc(size); 
+void *can_fail_malloc_havoc(size_t size) {
+    return nd_bool() ? NULL : bounded_malloc_havoc(size);
 }
 
 /**
@@ -16,7 +22,7 @@ void *can_fail_malloc(size_t size) {
  */
 static void *s_malloc_allocator(struct aws_allocator *allocator, size_t size) {
   (void)allocator;
-  return bounded_malloc(size);
+  return bounded_malloc_havoc(size);
 }
 
 /**

--- a/seahorn/lib/klee_array_list_helper.c
+++ b/seahorn/lib/klee_array_list_helper.c
@@ -32,7 +32,7 @@ void initialize_bounded_array_list(struct aws_array_list *const list) {
   list->current_size = nd_size_t();
   assume(list->current_size <= klee_max_memory_size());
   list->item_size = nd_size_t();
-  list->data = can_fail_malloc(list->current_size);
+  list->data = can_fail_malloc_havoc(list->current_size);
   if (list->data) {
     list->length = nd_size_t();
   }

--- a/seahorn/lib/klee_byte_buf_helper.c
+++ b/seahorn/lib/klee_byte_buf_helper.c
@@ -18,7 +18,7 @@
 void initialize_byte_buf(struct aws_byte_buf *const buf) {
     size_t cap = nd_size_t();
     assume(cap <= sea_max_buffer_size());
-    buf->buffer = can_fail_malloc(cap * sizeof(*(buf->buffer)));
+    buf->buffer = can_fail_malloc_havoc(cap * sizeof(*(buf->buffer)));
     if (buf->buffer) {
         size_t len = nd_size_t();
         assume(len <= cap);
@@ -34,7 +34,7 @@ void initialize_byte_buf(struct aws_byte_buf *const buf) {
 
 void initialize_byte_cursor(struct aws_byte_cursor *const cursor) {
     size_t max_buffer_size = sea_max_buffer_size();
-    cursor->ptr = can_fail_malloc(sizeof(*(cursor->ptr)) * max_buffer_size);
+    cursor->ptr = can_fail_malloc_havoc(sizeof(*(cursor->ptr)) * max_buffer_size);
     if (cursor->ptr){
         cursor->len = nd_size_t();
         assume(cursor->len <= max_buffer_size);
@@ -67,7 +67,7 @@ bool aws_byte_cursor_is_bounded(
 void ensure_byte_buf_has_allocated_buffer_member(
     struct aws_byte_buf *const buf) {
     buf->allocator = sea_allocator();
-    buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
+    buf->buffer = bounded_malloc_havoc(sizeof(*(buf->buffer)) * buf->capacity);
     size_t len = nd_size_t();
     assume(len <= buf->capacity);
     buf->len = len;

--- a/seahorn/lib/klee_hash_table_helper.c
+++ b/seahorn/lib/klee_hash_table_helper.c
@@ -24,7 +24,7 @@ void initialize_bounded_aws_hash_table(struct aws_hash_table *map,
   /* assume setting required_bytes is successful */
   assume(hash_table_state_required_bytes(num_entries, &required_bytes) ==
          AWS_OP_SUCCESS);
-  struct hash_table_state *impl = bounded_malloc(required_bytes);
+  struct hash_table_state *impl = bounded_malloc_havoc(required_bytes);
   impl->size = num_entries;
   impl->mask = num_entries - 1;
   impl->max_load_factor = 0.95;

--- a/seahorn/lib/klee_ring_buffer_helper.c
+++ b/seahorn/lib/klee_ring_buffer_helper.c
@@ -10,7 +10,7 @@ void initialize_ring_buffer(struct aws_ring_buffer *ring_buf,
   ring_buf->allocator = sea_allocator();
   /* The `aws_ring_buffer_init` function requires size > 0. */
   assume(0 < size && size <= KLEE_MAX_SIZE);
-  ring_buf->allocation = bounded_malloc(size);
+  ring_buf->allocation = bounded_malloc_havoc(size);
   size_t position_head = nd_size_t();
   size_t position_tail = nd_size_t();
   assume(position_head < size);

--- a/seahorn/lib/klee_string_helper.c
+++ b/seahorn/lib/klee_string_helper.c
@@ -6,7 +6,7 @@
 
 struct aws_string *ensure_string_is_allocated(size_t len) {
   size_t alloc_size = sizeof(struct aws_string) + len + 1;
-  struct aws_string *str = bounded_malloc(alloc_size);
+  struct aws_string *str = bounded_malloc_havoc(alloc_size);
 
   if (str) {
     memhavoc(str, alloc_size); // only memhavoc if allocation succeeded
@@ -55,10 +55,10 @@ static const char *_ensure_c_str_is_nd_allocated(size_t max_size, size_t *len,
 
     char *str = NULL;
     if (safe) {
-      str = bounded_malloc(alloc_size);
+      str = bounded_malloc_havoc(alloc_size);
     }
     else {
-      str = can_fail_malloc(alloc_size);
+      str = can_fail_malloc_havoc(alloc_size);
       if (!str) {
         return NULL;
       }

--- a/seahorn/lib/nd_fuzz.c
+++ b/seahorn/lib/nd_fuzz.c
@@ -22,13 +22,11 @@ jmp_buf g_jmp_buf;
   }
 
 bool nd_bool(void) {
-  bool res;
-
+  int tmp;
   UPDATE_FUZZ_ITERATOR(bool)
-  memcpy(&res, g_fuzz_data_iterator, sizeof(bool));
+  memcpy(&tmp, g_fuzz_data_iterator, sizeof(bool));
   g_fuzz_data_iterator += sizeof(bool);
-
-  return res;
+  return (tmp > 0);
 }
 
 int nd_int(void) {

--- a/seahorn/lib/proof_allocators.c
+++ b/seahorn/lib/proof_allocators.c
@@ -13,11 +13,11 @@
 
 void *realloc(void *ptr, size_t new_size) { return sea_realloc(ptr, new_size); }
 
-void *bounded_malloc(size_t size) {
+void *bounded_malloc_havoc(size_t size) {
   return size == 0 ? NULL : sea_malloc_havoc_safe(size);
 }
 
-void *can_fail_malloc(size_t size) {
+void *can_fail_malloc_havoc(size_t size) {
   return size == 0 ? NULL : sea_malloc_havoc(size);
 }
 
@@ -27,9 +27,9 @@ void *can_fail_malloc(size_t size) {
 static void *s_malloc_allocator(struct aws_allocator *allocator, size_t size) {
   (void)allocator;
 #ifdef SEA_ALLOCATOR_CAN_FAIL
-  return can_fail_malloc(size);
+  return can_fail_malloc_havoc(size);
 #else
-  return bounded_malloc(size);
+  return bounded_malloc_havoc(size);
 #endif
 }
 

--- a/seahorn/lib/ring_buffer_helper.c
+++ b/seahorn/lib/ring_buffer_helper.c
@@ -10,7 +10,7 @@ void initialize_ring_buffer(struct aws_ring_buffer *ring_buf,
   ring_buf->allocator = sea_allocator();
   /* The `aws_ring_buffer_init` function requires size > 0. */
   assume(0 < size);
-  ring_buf->allocation = bounded_malloc(size);
+  ring_buf->allocation = bounded_malloc_havoc(size);
   size_t position_head = nd_size_t();
   size_t position_tail = nd_size_t();
   assume(position_head < size);

--- a/seahorn/lib/smack_allocators.c
+++ b/seahorn/lib/smack_allocators.c
@@ -8,13 +8,14 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-
-
-void *bounded_malloc(size_t size) {
-    return size == 0 ? NULL : malloc(size);
+// Always succeeds in allocating memory to have same behaviour as SEAHORN
+void *bounded_malloc_havoc(size_t size) {
+  void *data = malloc(size);
+  memhavoc(data, size);
+  return data;
 }
 
-void *can_fail_malloc(size_t size) {
+void *can_fail_malloc_havoc(size_t size) {
   if (size == 0)
     return NULL;
   // initialize nondetermined values into allocated memory
@@ -28,7 +29,7 @@ void *can_fail_malloc(size_t size) {
  */
 static void *s_malloc_allocator(struct aws_allocator *allocator, size_t size) {
   (void)allocator;
-  return bounded_malloc(size);
+  return bounded_malloc_havoc(size);
 }
 
 /**


### PR DESCRIPTION
1. Document differences between seahorn, fuzz, klee and smack -- in some cases, malloc fails, in others it does not
2. Rename malloc to malloc_havoc to clarify what is expected to happen