### PR TITLE
fix(fuzzing): UAF and hash entry count

### DIFF
--- a/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
+++ b/seahorn/jobs/hash_table_clean_up/aws_hash_table_clean_up_harness.c
@@ -31,8 +31,9 @@ int main(void) {
 
   // this reads memory that has been freed, but we are not currently modelling
   // freeing memory
-  #ifdef __KLEE__
+  #if defined(__KLEE__) || defined(__FUZZ__)
     // klee does not allow to access memory after free.
+    // run-time UAF will be detected as by Address Sanitizer used by libFuzzer
   #else
   size_t i = nd_size_t();
   size_t len = state->size * sizeof(state->slots[0]);

--- a/seahorn/jobs/hash_table_foreach/aws_hash_table_foreach_harness.c
+++ b/seahorn/jobs/hash_table_foreach/aws_hash_table_foreach_harness.c
@@ -20,7 +20,10 @@ int main(void) {
   struct aws_hash_table map;
   initialize_bounded_aws_hash_table(&map, MAX_TABLE_SIZE);
   ensure_hash_table_has_valid_destroy_functions(&map);
-//   assume(aws_hash_table_entry_count_is_valid(&map));
+  #ifdef __FUZZ__
+  // otherwise pre-condition for deletion might fail
+  assume(aws_hash_table_entry_count_is_valid(&map));
+  #endif
   map.p_impl->equals_fn = nondet_equals;
   map.p_impl->hash_fn = uninterpreted_hasher;
   assume(aws_hash_table_is_valid(&map));

--- a/seahorn/lib/fuzz_hash_table_helper.c
+++ b/seahorn/lib/fuzz_hash_table_helper.c
@@ -125,9 +125,10 @@ void initialize_aws_hash_iter(struct aws_hash_iter *iter,
   iter->element.value = nd_voidp();
   iter->slot = nd_size_t();
   iter->limit = nd_size_t();
-  assume(iter->limit > 0);
-  // iter->limit <= iter->map->p_impl->size
+  // 0 < iter->limit <= iter->map->p_impl->size
   iter->limit %= iter->map->p_impl->size;
+  if (iter->limit == 0)
+    iter->limit = iter->map->p_impl->size;
   // iter->slot < iter->limit
   iter->slot %= iter->limit;
   iter->status = nd_hash_iter_status();

--- a/seahorn/lib/nd_fuzz.c
+++ b/seahorn/lib/nd_fuzz.c
@@ -22,13 +22,11 @@ jmp_buf g_jmp_buf;
   }
 
 bool nd_bool(void) {
-  bool res;
-
+  int tmp;
   UPDATE_FUZZ_ITERATOR(bool)
-  memcpy(&res, g_fuzz_data_iterator, sizeof(bool));
+  memcpy(&tmp, g_fuzz_data_iterator, sizeof(bool));
   g_fuzz_data_iterator += sizeof(bool);
-
-  return res;
+  return (tmp > 0);
 }
 
 int nd_int(void) {


### PR DESCRIPTION
Havoc after malloc must have opened up a lot more interesting execution paths, thus exposing some mistakes overlooked during creating the fuzzing tests.
Tested all fuzzing tests locally.