### PR TITLE
Unsafe job for aws mem realloc

### DIFF
--- a/.github/workflows/blacklist.vac.txt
+++ b/.github/workflows/blacklist.vac.txt
@@ -3,3 +3,5 @@ hash_table_foreach_unsat_test
 hash_table_eq_unsat_test
 # following test is a spurious intermittent failure in CI
 nospec_mask_unsat_test
+# folowing test is failed as expect because it is sat test
+mem_realloc_unsafe_sat_test

--- a/seahorn/CMakeLists.txt
+++ b/seahorn/CMakeLists.txt
@@ -373,6 +373,11 @@ function(sea_add_unsat_test TARGET)
   add_test(NAME "${TARGET}_unsat_test" COMMAND ${VERIFY_CMD} ${VERIFY_FLAGS} --expect=unsat ${BC})
 endfunction()
 
+function(sea_add_sat_test TARGET)
+  sea_get_file_name(BC ${TARGET}.ir)
+  add_test(NAME "${TARGET}_sat_test" COMMAND ${VERIFY_CMD} ${VERIFY_FLAGS} --expect=sat ${BC})
+endfunction()
+
 set(FUZZ_FLAGS corpus -use_value_profile=1 -detect_leaks=0 -runs=50000 -timeout=60 -rss_limit_mb=4096 CACHE STRING "Flags for fuzzing")
 separate_arguments(FUZZ_FLAGS)
 
@@ -660,6 +665,8 @@ add_subdirectory(jobs2/ring_buffer_acquire2)
 add_subdirectory(jobs2/ring_buffer_release2)
 add_subdirectory(jobs2/ring_buffer_buf_belongs_to_pool2)
 add_subdirectory(jobs2/ring_buffer_acquire_up_to2)
+
+add_subdirectory(jobs_unsafe/mem_realloc_unsafe)
 
 if(${SEA_WITH_BLEEDING_EDGE})
   add_subdirectory(jobs/priority_queue_s_swap)

--- a/seahorn/CMakeLists.txt
+++ b/seahorn/CMakeLists.txt
@@ -368,11 +368,13 @@ endmacro()
 set(VERIFY_FLAGS $ENV{VERIFY_FLAGS} CACHE STRING "Flags for verify script")
 separate_arguments(VERIFY_FLAGS)
 
+# Unit test for testing unsat
 function(sea_add_unsat_test TARGET)
   sea_get_file_name(BC ${TARGET}.ir)
   add_test(NAME "${TARGET}_unsat_test" COMMAND ${VERIFY_CMD} ${VERIFY_FLAGS} --expect=unsat ${BC})
 endfunction()
 
+# Unit test for testing sat
 function(sea_add_sat_test TARGET)
   sea_get_file_name(BC ${TARGET}.ir)
   add_test(NAME "${TARGET}_sat_test" COMMAND ${VERIFY_CMD} ${VERIFY_FLAGS} --expect=sat ${BC})

--- a/seahorn/include/proof_allocators.h
+++ b/seahorn/include/proof_allocators.h
@@ -32,3 +32,8 @@ void *can_fail_malloc_havoc(size_t size);
  * Pointer to SeaHorn-based allocator
  */
 struct aws_allocator *sea_allocator(void);
+
+/**
+ * Pointer to SeaHorn-based allocator with realloc
+ */
+struct aws_allocator *sea_allocator_with_realloc(void);

--- a/seahorn/jobs_unsafe/mem_realloc_unsafe/CMakeLists.txt
+++ b/seahorn/jobs_unsafe/mem_realloc_unsafe/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(mem_realloc_unsafe
+  ${AWS_C_COMMON_ROOT}/source/allocator.c
+  ${SEA_LIB}/bcmp.c
+  ${SEA_LIB}/proof_allocators.c
+  ${SEA_LIB}/sea_allocators.c
+  aws_mem_realloc_unsafe_harness.c)
+
+sea_link_libraries(mem_realloc_unsafe sea_bounds.ir)
+sea_attach_bc(mem_realloc_unsafe)
+sea_add_sat_test(mem_realloc_unsafe)

--- a/seahorn/jobs_unsafe/mem_realloc_unsafe/CMakeLists.txt
+++ b/seahorn/jobs_unsafe/mem_realloc_unsafe/CMakeLists.txt
@@ -7,4 +7,8 @@ add_executable(mem_realloc_unsafe
 
 sea_link_libraries(mem_realloc_unsafe sea_bounds.ir)
 sea_attach_bc(mem_realloc_unsafe)
+# This proof is sat because there is a bug in aws-c-commons
+# aws_mem_realloc can be failed by calling mem_cpy
+# Since there are no preconditions for the void **ptr and size oldsize. 
+# The *ptr could be a NULL and the oldsize > 0.
 sea_add_sat_test(mem_realloc_unsafe)

--- a/seahorn/jobs_unsafe/mem_realloc_unsafe/aws_mem_realloc_unsafe_harness.c
+++ b/seahorn/jobs_unsafe/mem_realloc_unsafe/aws_mem_realloc_unsafe_harness.c
@@ -16,7 +16,6 @@ int main() {
     size_t old_size = nd_size_t();
 
     size_t new_size = nd_size_t();
-    assume(old_size <= new_size);
 
     aws_mem_realloc(allocator, (void **)&data, old_size, new_size);
 

--- a/seahorn/jobs_unsafe/mem_realloc_unsafe/aws_mem_realloc_unsafe_harness.c
+++ b/seahorn/jobs_unsafe/mem_realloc_unsafe/aws_mem_realloc_unsafe_harness.c
@@ -1,0 +1,24 @@
+/*
+ * 
+ */
+
+#include <seahorn/seahorn.h>
+#include <aws/common/allocator.h>
+#include "proof_allocators.h"
+#include "nondet.h"
+
+int main() {
+
+    struct aws_allocator *allocator = nd_bool() ? sea_allocator() : sea_allocator_with_realloc();
+
+    void *data = NULL;
+
+    size_t old_size = nd_size_t();
+
+    size_t new_size = nd_size_t();
+    assume(old_size <= new_size);
+
+    aws_mem_realloc(allocator, (void **)&data, old_size, new_size);
+
+    return 0;
+}

--- a/seahorn/lib/proof_allocators.c
+++ b/seahorn/lib/proof_allocators.c
@@ -51,7 +51,6 @@ static void *s_realloc_allocator(struct aws_allocator *allocator, void *ptr, siz
 
   /* newsize is > oldsize, need more memory */
   void *new_mem = s_malloc_allocator(allocator, newsize);
-  // AWS_PANIC_OOM(new_mem, "Unhandled OOM encountered in s_malloc_allocator");
 
   if (ptr) {
     memcpy(new_mem, ptr, oldsize);


### PR DESCRIPTION
This PR includes a simple unsafe test for a bug we found on the `aws_mem_realloc` function: 
https://github.com/awslabs/aws-c-common/blob/5fa4275653600b66cdbfee8fcf407eb4416f6b18/source/allocator.c#L217

- Bug descriptions.
`aws_mem_realloc` could failed on calling `mem_cpy`:
https://github.com/awslabs/aws-c-common/blob/5fa4275653600b66cdbfee8fcf407eb4416f6b18/source/allocator.c#L245
Because the `*ptr` could be a `NULL` and the `oldsize > 0`.
- Why this is a bug?
Since there are no preconditions for the `void **ptr` and size `oldsize`. The `*ptr` could be a `NULL` and the `oldsize > 0`.
Another precondition is when there is no mem realloc in the aws allocator (realloc is an optional):
https://github.com/awslabs/aws-c-common/blob/5fa4275653600b66cdbfee8fcf407eb4416f6b18/include/aws/common/allocator.h#L18-L19